### PR TITLE
giza_parse_string() fix, add cpgqinf() support, fix critical bug found doing this

### DIFF
--- a/src/giza-drivers-private.h
+++ b/src/giza-drivers-private.h
@@ -38,7 +38,7 @@
 int _giza_get_key_press (int mode, int moveCurs, int nanc, const double *xanc, const double *yanc, double *x, double *y, char *ch);
 void _giza_split_device_string (const char *deviceString, char const **devType);
 int _giza_device_to_int (const char *newDeviceName);
-int _giza_int_to_device (int numDevice, char *DeviceName);
+int _giza_int_to_device (int numDevice, char *DeviceName, int rval);
 void _giza_init_norm (void);
 void _giza_expand_clipping (void);
 void _giza_restore_clipping (void);

--- a/src/giza-drivers.c
+++ b/src/giza-drivers.c
@@ -566,6 +566,7 @@ giza_close_device (void)
  *
  * Input:
  *  -querytype :- a string containing the query type
+ *  -rlen      :- integer containing the length of the return buffer
  *
  * Output:
  *  -returnval :- string with result of query
@@ -582,86 +583,74 @@ giza_close_device (void)
  *
  */
 int
-giza_query_device (const char *querytype, char *returnval)
+giza_query_device (const char *querytype, char *returnval, int* rlen)
 {
-  int ierr;
-  ierr = 0;
-  char devType[12];
+  int       ierr = 0;
+  char      devType[12];
+  const int max_chars = *rlen - 1;
 
+  if (max_chars<=0)
+    {
+        _giza_warning("giza_query_device", "destination string says it has %d characters available querying %s", max_chars, querytype);
+        return 1;
+    }
   /* Query device type */
 
-  if (!strcmp(querytype,"type"))
+  if (!strcasecmp(querytype,"type"))
      {
-       if (!_giza_int_to_device(Dev[id].type,returnval))
+       if (!_giza_int_to_device(Dev[id].type,returnval, max_chars))
          {
            ierr = 1;
          }
      }
   /* Query whether or not device has cursor */
-  else if (!strcmp(querytype,"cursor"))
+  else if (!strcasecmp(querytype,"cursor"))
     {
-      if (Dev[id].isInteractive)
-        {
-          strncpy(returnval,"YES",sizeof(returnval)-1);
-        }
-      else
-        {
-          strncpy(returnval,"NO",sizeof(returnval)-1);
-        }
+      strncpy(returnval, Dev[id].isInteractive ? "YES" : "NO", max_chars);
     }
   /* Query whether or not device is hard copy or not */
-  else if (!strcmp(querytype,"hardcopy"))
+  else if (!strcasecmp(querytype,"hardcopy"))
     {
-      if (Dev[id].isInteractive)
-        {
-          strncpy(returnval,"NO",sizeof(returnval)-1);
-        }
-      else
-        {
-          strncpy(returnval,"YES",sizeof(returnval)-1);
-        }
+      strncpy(returnval, Dev[id].isInteractive ? "NO" : "YES", max_chars);
     }
   /* Query whether or not device is open or not */
-  else if (!strcmp(querytype,"state"))
+  else if (!strcasecmp(querytype,"state"))
     {
-       if (Dev[id].deviceOpen)
-         {
-            strncpy(returnval,"OPEN",sizeof(returnval)-1);         
-         }
-       else
-         {
-            strncpy(returnval,"CLOSED",sizeof(returnval)-1);
-         }    
+      strncpy(returnval, Dev[id].deviceOpen ? "OPEN" : "CLOSED", max_chars);
     }
   /* Query current user */
-  else if (!strcmp(querytype,"user"))
+  else if (!strcasecmp(querytype,"user"))
     {
-       strncpy(returnval,getlogin(),sizeof(returnval)-1);
+       strncpy(returnval,getlogin(),max_chars);
     }
   /* Query current device name */
-  else if (!strcmp(querytype,"device"))
+  else if (!strcasecmp(querytype,"device"))
     {
-       strncpy(returnval,Dev[id].prefix,sizeof(returnval)-1);
+       strncpy(returnval,Dev[id].prefix,max_chars);
     }
   /* Query current device/type */
-  else if (!strcmp(querytype,"dev/type"))
+  else if (!strcasecmp(querytype,"dev/type"))
     {
-       strncpy(returnval,Dev[id].prefix,sizeof(returnval)-1);
-       if (!_giza_int_to_device(Dev[id].type,devType))
+       strncpy(returnval,Dev[id].prefix,max_chars);
+       if (!_giza_int_to_device(Dev[id].type,devType,sizeof(devType)))
          {
            ierr = 1;
            strncat(returnval,devType,4*sizeof(char));
          }
     }
   /* Query current filename (as entered by user) */
-  else if (!strcmp(querytype,"file"))
+  else if (!strcasecmp(querytype,"file"))
     {
        if (!Dev[id].isInteractive)
          {
-           strncpy(returnval,Dev[id].prefix,sizeof(returnval)-1);
+           strncpy(returnval,Dev[id].prefix,max_chars);
+         }
+       else 
+         {
+           strncpy(returnval, " ", max_chars);
          }
     }
-  returnval[sizeof(returnval)-1] = '\0'; /* make sure string is null-terminated */
+  returnval[max_chars] = '\0'; /* make sure string is null-terminated */
   return ierr;
 }
 
@@ -834,51 +823,51 @@ _giza_device_to_int (const char *newDeviceName)
  * An internal function that the integer representation back to the device string
  */
 int
-_giza_int_to_device (int numDevice, char *DeviceName)
+_giza_int_to_device (int numDevice, char *DeviceName, int rval)
 {
 
- int ierr;
- ierr = 0;
+ int       ierr = 0;
+ const int max_chars = rval - 1;
  switch (numDevice)
     {
     case GIZA_DEVICE_NULL:
-      strncpy(DeviceName,"/null",sizeof(DeviceName)-1);
+      strncpy(DeviceName,"/null",max_chars);
       break;
     case GIZA_DEVICE_PDF:
-      strncpy(DeviceName,"/pdf",sizeof(DeviceName)-1);
+      strncpy(DeviceName,"/pdf",max_chars);
       break;
     case GIZA_DEVICE_VPDF:
-      strncpy(DeviceName,"/vpdf",sizeof(DeviceName)-1);
+      strncpy(DeviceName,"/vpdf",max_chars);
       break;
     case GIZA_DEVICE_PNG:
-      strncpy(DeviceName,"/png",sizeof(DeviceName)-1);
+      strncpy(DeviceName,"/png",max_chars);
       break;
     case GIZA_DEVICE_SVG:
-      strncpy(DeviceName,"/svg",sizeof(DeviceName)-1);
+      strncpy(DeviceName,"/svg",max_chars);
       break;
     case GIZA_DEVICE_PS:
-      strncpy(DeviceName,"/ps",sizeof(DeviceName)-1);
+      strncpy(DeviceName,"/ps",max_chars);
       break;
     case GIZA_DEVICE_VPS:
-      strncpy(DeviceName,"/vps",sizeof(DeviceName)-1);
+      strncpy(DeviceName,"/vps",max_chars);
       break;
 #ifdef _GIZA_HAS_XW
     case GIZA_DEVICE_XW:
-      strncpy(DeviceName,"/xw",sizeof(DeviceName)-1);
+      strncpy(DeviceName,"/xw",max_chars);
       break;
 #endif
 #ifdef _GIZA_HAS_EPS
     case GIZA_DEVICE_EPS:
-      strncpy(DeviceName,"/eps",sizeof(DeviceName)-1);
+      strncpy(DeviceName,"/eps",max_chars);
       break;
 #endif
     default:
     /* Do not print an error here as this is an internal routine:
        Instead, make sure the error is handled in the calling routine */
-      strncpy(DeviceName," ",sizeof(DeviceName)-1);
+      strncpy(DeviceName," ",max_chars);
       ierr = 1;
     }
-    DeviceName[sizeof(DeviceName)-1] = '\0'; /* make sure string is null-terminated */
+    DeviceName[max_chars] = '\0'; /* make sure string is null-terminated */
     return ierr;
 }
 

--- a/src/giza-fortran.F90
+++ b/src/giza-fortran.F90
@@ -1641,10 +1641,11 @@ private
  end interface
 
  interface giza_query_device_c
-    integer(kind=c_int) function giza_query_device_c(qtype,string) bind(C,name="giza_query_device")
+    integer(kind=c_int) function giza_query_device_c(qtype,string,rval) bind(C,name="giza_query_device")
       import
       character(kind=c_char),dimension(*),intent(in)  :: qtype
       character(kind=c_char),dimension(*),intent(out) :: string
+      integer(kind=c_int),intent(out) :: rval
     end function giza_query_device_c
  end interface
 !------------------ end of interfaces -----------------------
@@ -1919,10 +1920,11 @@ contains
     implicit none
     character(len=*),intent(in)  :: qtype
     character(len=*),intent(out) :: string
+    integer(kind=c_int) :: rval
     integer(kind=c_int) :: ierr
     character(kind=c_char), dimension(len(string)+1) :: stringc
-    
-    ierr = giza_query_device_c(cstring(qtype),stringc)
+    rval = len(string)+1 
+    ierr = giza_query_device_c(cstring(qtype),stringc,rval)
     string = fstring(stringc)
   
   end subroutine giza_query_device_f2c

--- a/src/giza-scanner.l
+++ b/src/giza-scanner.l
@@ -326,9 +326,9 @@ _giza_parse_string (const char *text, double *width, double *height, void (*acti
                    not inked.
              The upshot is that x^2\b\b_i renders nicely as proper x-i-squared */
           case GIZA_TOKEN_BACKSPACE:
-              bckSpace -= 1;
               if( bckSpace>=0 )
                   cairo_move_to(Dev[id].context, positions[bckSpace].x, positions[bckSpace].y);
+              bckSpace -= 1;
               break;
 
           /* Handle change of font! The lexer already verified it's a /valid/ font specifier */

--- a/src/giza.h
+++ b/src/giza.h
@@ -151,7 +151,7 @@ void giza_get_device_id (int *devid);
 void giza_flush_device (void);
 void giza_change_page (void);
 void giza_close_device (void);
-int giza_query_device (const char *querytype, char *returnval);
+int giza_query_device (const char *querytype, char *returnval, int* rlen);
 int giza_device_has_cursor (void);
 int giza_get_key_press (double *x, double *y, char *ch);
 int giza_get_key_press_float (float *x, float *y, char *ch);

--- a/src/lex.yy.c
+++ b/src/lex.yy.c
@@ -2403,9 +2403,9 @@ _giza_parse_string (const char *text, double *width, double *height, void (*acti
                    not inked.
              The upshot is that x^2\b\b_i renders nicely as proper x-i-squared */
           case GIZA_TOKEN_BACKSPACE:
-              bckSpace -= 1;
               if( bckSpace>=0 )
                   cairo_move_to(Dev[id].context, positions[bckSpace].x, positions[bckSpace].y);
+              bckSpace -= 1;
               break;
 
           /* Handle change of font! The lexer already verified it's a /valid/ font specifier */


### PR DESCRIPTION
- Due to my inadequate regression test scheme missed an off-by-one in `giza_parse_string()` backspace handling; it worked for the tests I checked but I did not carefully enough test *all* `pgdemo`'s. One line change.

- Added support for `cpgqinf()` to query device information. `PGQINF()` was implemented in the FORTRAN pgplot library but not in the C-language binding.

- Whilst adding support for `cpgqinf()` I found a critical misconception in two `giza_...` functions used by this and fixed them. This required changes in the FORTRAN binding code too. See the commit message.