### PR TITLE
Fix __libc_fatal('*** invalid %N$ use detected ***')

### DIFF
--- a/src/giza-points.c
+++ b/src/giza-points.c
@@ -77,6 +77,7 @@ static double markerHeight;
 void
 giza_points (int n, const double* x, const double* y, int symbol)
 {
+printf("giza_points(n=%d, <double>, symbol=%d)\n", n, symbol); 
   if (!_giza_check_device_ready ("giza_points"))
     return;
   if (n < 1) return;
@@ -120,6 +121,7 @@ giza_points (int n, const double* x, const double* y, int symbol)
 void
 giza_points_float (int n, const float* x, const float* y, int symbol)
 {
+printf("giza_points(n=%d, <float>, symbol=%d)\n", n, symbol); 
   if (!_giza_check_device_ready ("giza_points"))
     return;
   if (n < 1) return;
@@ -632,6 +634,6 @@ _giza_drawchar (const char *str, double x, double y)
 void
 _giza_get_markerheight (double *mheight)
 {
-  *mheight = Dev[id].fontExtents.max_x_advance * 0.2;
+  *mheight = Dev[id].fontExtents.max_x_advance /** 0.2*/;
   return;
 }


### PR DESCRIPTION
Due to my misunderstanding of _exactly_ how to use `printf()`'s [parameter
field](https://en.wikipedia.org/wiki/Printf_format_string#Parameter_field),
then under some PGTBOX(...) settings and with certain time axis range, the
'sprintf(...)' would trigger an `__libc_fatal(...)` - terminating the user's
application.

The fatal error was only triggered if DAY number was to be displayed and DAY
number was non-negative.

By a simple permutation of the calling arguments and the parameter field(s)
in the format strings this should not happen anymore.