### PR TITLE
Fix __libc_fatal('*** invalid %N$ use detected ***')

### DIFF
--- a/src/giza-box-time.c
+++ b/src/giza-box-time.c
@@ -1082,9 +1082,9 @@ void pgtbx7(char const* suptyp, char signf, char asign, int ival[3], double rval
     if( writ[0] ) {
         /* depending on wether to print the sign or not choose the correct
          * format */
-        char const* fmt = (signf=='D' && asign!=' ') ? "%1$c%2$d%3$s" : "%2$d%3$s" ;
+        char const* fmt = (signf=='D' && asign!=' ') ? "%3$c%1$d%2$s" : "%1$d%2$s" ;
         *last  = *tlen;
-        nch   = sprintf(&text[*tlen], fmt, asign, ival[0], suppnt[0]);
+        nch   = sprintf(&text[*tlen], fmt, ival[0], suppnt[0], asign);
         *tlen = *tlen + nch;
     }
 


### PR DESCRIPTION
Due to my misunderstanding of _exactly_ how to use `printf()`'s [parameter
field](https://en.wikipedia.org/wiki/Printf_format_string#Parameter_field),
then under some PGTBOX(...) settings and with certain time axis range, the
'sprintf(...)' would trigger a `__libc_fatal(...)` - terminating the user's
application.

The fatal error was only triggered if DAY number was to be displayed and DAY
number was non-negative.

By a simple permutation of the calling arguments and the parameter field(s)
in the format strings this should not happen anymore.