### PR TITLE
Fixes #5 Symbol issues

### DIFF
--- a/src/giza-box-time.c
+++ b/src/giza-box-time.c
@@ -1082,9 +1082,9 @@ void pgtbx7(char const* suptyp, char signf, char asign, int ival[3], double rval
     if( writ[0] ) {
         /* depending on wether to print the sign or not choose the correct
          * format */
-        char const* fmt = (signf=='D' && asign!=' ') ? "%1$c%2$d%3$s" : "%2$d%3$s" ;
+        char const* fmt = (signf=='D' && asign!=' ') ? "%3$c%1$d%2$s" : "%1$d%2$s" ;
         *last  = *tlen;
-        nch   = sprintf(&text[*tlen], fmt, asign, ival[0], suppnt[0]);
+        nch   = sprintf(&text[*tlen], fmt, ival[0], suppnt[0], asign);
         *tlen = *tlen + nch;
     }
 

--- a/src/giza-points.c
+++ b/src/giza-points.c
@@ -35,7 +35,7 @@
 
 /* Internal functions */
 static void _giza_point        (double x, double y);
-static void _giza_rect         (double x, double y, int fill);
+static void _giza_rect         (double x, double y, int fill, double scale);
 static void _giza_rect_concave (double x, double y, int fill, double scale, double bulge_fraction);
 static void _giza_plus         (double x, double y);
 static void _giza_fat_plus     (double x, double y, int fill, double scale, double inset_fraction);
@@ -327,9 +327,8 @@ _giza_draw_symbol (double xd, double yd, int symbol)
           }
           /*_giza_circle_size (xd, yd, 0.33*fabs(symbol-19), 0);*/
           break;
-        case 19: /* hexagon with cross */
-          _giza_polygon (xd, yd, 6, 0);
-          _giza_cross (xd, yd);
+        case 19: /* slightly larger open rect (just shy of 3x size of #6 */
+	      _giza_rect (xd, yd, 0, 3.5);
           break;
         case 18: /* Filled version of symbol 12 (five-pointed star) */
           _giza_star (xd, yd, 5, 0.4, 1, 2.3);
@@ -338,7 +337,7 @@ _giza_draw_symbol (double xd, double yd, int symbol)
 	  _giza_circle_size (xd, yd, 0.75, 1);
           break;
         case 16: /* filled square */
-	  _giza_rect (xd, yd, 1);
+	  _giza_rect (xd, yd, 1, 1.0);
           break;
         case 15: /* hollow up+down triangle, where we do slightly different raises on the the up/down triangle */
           _giza_triangle(xd, yd, 0, GIZA_POINT_UP,   0.7, 0.5);
@@ -388,7 +387,7 @@ _giza_draw_symbol (double xd, double yd, int symbol)
 	  break;
         case 6: /* hollow square */
 	case 0:
-	  _giza_rect (xd, yd, 0);
+	  _giza_rect (xd, yd, 0, 1.5);
 	  break;
 	case -1: /* single small point */
 	case -2:
@@ -424,12 +423,16 @@ _giza_point (double x, double y)
  * Draw a rectangle centred at x, y
  */
 static void
-_giza_rect (double x, double y, int fill)
+_giza_rect (double x, double y, int fill, double scale)
 {
-  cairo_rectangle (Dev[id].context, x - markerHeight * 0.5, y - markerHeight * 0.5, markerHeight,
-		   markerHeight);
-  if (fill) { cairo_fill(Dev[id].context); }
+  const double size = scale * markerHeight;
 
+  cairo_save( Dev[id].context );
+  cairo_set_line_width( Dev[id].context, 0.9 );
+  cairo_rectangle (Dev[id].context, x - 0.5 * size, y - 0.5 * size, size, size );
+  if (fill) { cairo_fill(Dev[id].context); }
+  cairo_stroke( Dev[id].context );
+  cairo_restore( Dev[id].context );
 }
 
 /**

--- a/src/giza-points.c
+++ b/src/giza-points.c
@@ -41,7 +41,7 @@ static void _giza_plus         (double x, double y);
 static void _giza_fat_plus     (double x, double y, int fill, double scale, double inset_fraction);
 static void _giza_triangle     (double x, double y, int fill, int updown, float scale, float offset_fraction);
 static void _giza_diamond      (double x, double y, int fill);
-static void _giza_polygon      (double x, double y, int nsides , int fill);
+static void _giza_polygon      (double x, double y, int nsides , int fill, double scale);
 static void _giza_star         (double x, double y, int npoints, double ratio, int fill, double scale);
 static void _giza_circle       (double x, double y);
 static void _giza_circle_size  (double x, double y, double size, int fill);
@@ -399,7 +399,8 @@ _giza_draw_symbol (double xd, double yd, int symbol)
 	case -6:
 	case -7:
 	case -8:
-          _giza_polygon (xd, yd, -symbol, 1);
+          /* scale those up a bit compared to original code */
+          _giza_polygon (xd, yd, -symbol, 1, 2.5);
           break;
 	default:
 	  _giza_point (xd, yd);
@@ -617,13 +618,14 @@ _giza_arrow (double x, double y, double angle, double scale)
 
 
 /**
- * Draws a general polygon at x, y
+ * Draws a general polygon at x, y with nsides sides at scale scale.
+ * Units of scale are 'normalized symbol size' = 0.5 * markerHeight
  */
 static void
-_giza_polygon (double x, double y, int nsides, int fill)
+_giza_polygon (double x, double y, int nsides, int fill, double scale)
 {
  /* Define radius */
- double r = 0.5 * markerHeight;
+ double r = scale * 0.5 * markerHeight;
 
  /* Set first vertex above marker position */
  double alpha = 1.5 * M_PI;

--- a/src/giza-points.c
+++ b/src/giza-points.c
@@ -316,7 +316,16 @@ _giza_draw_symbol (double xd, double yd, int symbol)
         case 22:
         case 21:
         case 20: 
-          _giza_circle_size (xd, yd, 0.33*fabs(symbol-19), 0);
+          {
+              /* It looks the open circles do not follow an exact linear scale 
+               * from 19 -> 27. In stead we make scale from 0.3 -> 12 in 8
+               * exponentional steps (27 - 19 = 8)
+               */
+              const double  minScale = 0.3, maxScale = 12, nStep = 27 - 19;
+              const double  factor   = pow(maxScale / minScale, 1./nStep);
+              _giza_circle_size (xd, yd, minScale * pow(factor, symbol-19), 0);
+          }
+          /*_giza_circle_size (xd, yd, 0.33*fabs(symbol-19), 0);*/
           break;
         case 19: /* hexagon with cross */
           _giza_polygon (xd, yd, 6, 0);
@@ -515,14 +524,19 @@ _giza_circle (double x, double y)
 
 /**
  * Draws a hollow circle at x, y, with size and fill arguments
+ * size is in units of 'canonical symbol size' (== 0.5 * markerHeight)
  */
 static void
 _giza_circle_size (double x, double y, double size, int fill)
 {
-  cairo_move_to(Dev[id].context, x + size*markerHeight*0.5, y);
+  /* use slightly thinner lines */
+  cairo_save( Dev[id].context );
+  cairo_set_line_width( Dev[id].context, 0.9 );
+  /*cairo_move_to(Dev[id].context, x + size*markerHeight*0.5, y);*/
   cairo_arc (Dev[id].context, x, y, size * markerHeight * 0.5, 0., 2. * M_PI);
   if (fill) { cairo_fill(Dev[id].context); }
-  _giza_stroke ();
+  cairo_stroke ( Dev[id].context );
+  cairo_restore( Dev[id].context );
 }
 
 /**

--- a/src/giza-points.c
+++ b/src/giza-points.c
@@ -443,7 +443,7 @@ _giza_rect_concave (double x, double y, int fill, double scale, double bulge_fra
 
   /* draw the four arcs with slightly thinner lines */
   cairo_save(Dev[id].context);
-  cairo_set_line_width(Dev[id].context, 1.1);
+  cairo_set_line_width(Dev[id].context, 0.9);
   cairo_arc(Dev[id].context, x + center, y, R, M_PI     - two_beta, M_PI     + two_beta);
   cairo_new_sub_path(Dev[id].context);
   cairo_arc(Dev[id].context, x - center, y, R, 2*M_PI   - two_beta, 2*M_PI   + two_beta);
@@ -452,6 +452,7 @@ _giza_rect_concave (double x, double y, int fill, double scale, double bulge_fra
   cairo_new_sub_path(Dev[id].context);
   cairo_arc(Dev[id].context, x, y + center, R, 3*M_PI_2 - two_beta, 3*M_PI_2 + two_beta);
   if (fill) { cairo_fill(Dev[id].context); }
+  cairo_stroke(Dev[id].context);
   cairo_restore(Dev[id].context);
 }
 
@@ -544,7 +545,7 @@ _giza_triangle(double x, double y, int fill, int updown, float scale, float offs
   cairo_line_to (Dev[id].context, x, y + updown * markerHeight * scale);
   cairo_close_path (Dev[id].context);
   if (fill) { cairo_fill(Dev[id].context); }
-  _giza_stroke ();
+  cairo_stroke (Dev[id].context);
   cairo_restore(Dev[id].context);
 }
 

--- a/src/giza-points.c
+++ b/src/giza-points.c
@@ -46,7 +46,7 @@ static void _giza_star         (double x, double y, int npoints, double ratio, i
 static void _giza_circle       (double x, double y);
 static void _giza_circle_size  (double x, double y, double size, int fill);
 static void _giza_cross        (double x, double y);
-static void _giza_arrow        (double x, double y, double angle);
+static void _giza_arrow        (double x, double y, double angle, double scale);
 static void _giza_char         (int symbol, double x, double y);
 static void _giza_drawchar     (const char *string, double x, double y);
 static void _giza_start_draw_symbols (int *oldTrans, int *oldLineStyle, int *oldLineCap,
@@ -297,16 +297,16 @@ _giza_draw_symbol (double xd, double yd, int symbol)
       switch (symbol)
 	{
         case 31: /* down arrow */
-          _giza_arrow (xd, yd, 0.5*M_PI);
+          _giza_arrow (xd, yd, 0.5*M_PI, 2.5);
           break;
         case 30: /* up arrow */
-          _giza_arrow (xd, yd, -0.5*M_PI);
+          _giza_arrow (xd, yd, -0.5*M_PI, 2.5);
           break;
         case 29: /* right arrow */
-          _giza_arrow (xd, yd, 0.);
+          _giza_arrow (xd, yd, 0., 2.5);
           break;
         case 28: /* left arrow */
-          _giza_arrow (xd, yd, M_PI);
+          _giza_arrow (xd, yd, M_PI, 2.5);
           break;
         case 27: /* hollow circles of various sizes */
         case 26:
@@ -596,15 +596,17 @@ _giza_cross (double x, double y)
 }
 
 /**
- * Draws an arrow at x, y
+ * Draws an arrow at x, y at scale 'scale'.
+ * Unit of scale is '0.5 * markerHeight' for the
+ * length of the arrow.
  */
 static void
-_giza_arrow (double x, double y, double angle)
+_giza_arrow (double x, double y, double angle, double scale)
 {
-  double headwidth  = 0.25*markerHeight;
-  double headlength = 0.25*markerHeight;
-  double r = 0.5*markerHeight;
-  double cosa = cos(angle); double sina = sin(angle);
+  const double r = scale * 0.5 * markerHeight;
+  const double headwidth  = 0.5 * r;
+  const double headlength = 0.5 * r;
+  const double cosa = cos(angle), sina = sin(angle);
   cairo_move_to (Dev[id].context, x - r*cosa, y - r*sina);
   cairo_line_to (Dev[id].context, x + r*cosa, y + r*sina);
   cairo_rel_line_to (Dev[id].context, - headlength*cosa + headwidth*sina, headwidth*cosa - headlength*sina);

--- a/src/giza-points.c
+++ b/src/giza-points.c
@@ -42,7 +42,7 @@ static void _giza_fat_plus     (double x, double y, int fill, double scale, doub
 static void _giza_triangle     (double x, double y, int fill, int updown, float scale, float offset_fraction);
 static void _giza_diamond      (double x, double y, int fill);
 static void _giza_polygon      (double x, double y, int nsides , int fill);
-static void _giza_star         (double x, double y, int npoints, double ratio, int fill);
+static void _giza_star         (double x, double y, int npoints, double ratio, int fill, double scale);
 static void _giza_circle       (double x, double y);
 static void _giza_circle_size  (double x, double y, double size, int fill);
 static void _giza_cross        (double x, double y);
@@ -315,17 +315,15 @@ _giza_draw_symbol (double xd, double yd, int symbol)
         case 23:
         case 22:
         case 21:
-          _giza_circle_size (xd, yd, 0.33*fabs(symbol-20), 0);
-          break;
-        case 20: /* 7 pointed star */
-          _giza_star (xd, yd, 7, 0.25, 0);
+        case 20: 
+          _giza_circle_size (xd, yd, 0.33*fabs(symbol-19), 0);
           break;
         case 19: /* hexagon with cross */
           _giza_polygon (xd, yd, 6, 0);
           _giza_cross (xd, yd);
           break;
-        case 18: /* filled diamond */
-          _giza_diamond (xd, yd, 1);
+        case 18: /* Filled version of symbol 12 (five-pointed star) */
+          _giza_star (xd, yd, 5, 0.4, 1, 2.3);
           break;
 	case 17: /* solid circle */
 	  _giza_circle_size (xd, yd, 0.75, 1);
@@ -344,7 +342,7 @@ _giza_draw_symbol (double xd, double yd, int symbol)
           _giza_triangle(xd, yd, 1, GIZA_POINT_UP, 0.7, 1);
           break;
         case 12: /* five-pointed star */
-          _giza_star (xd, yd, 5, 0.5, 0);
+          _giza_star (xd, yd, 5, 0.4, 0, 2.0);
           break;
         case 11: /* hollow diamond */
           _giza_diamond (xd, yd, 0);
@@ -634,21 +632,25 @@ _giza_polygon (double x, double y, int nsides, int fill)
  * Draws an n-pointed star at x,y
  */
 static void
-_giza_star (double x, double y, int npoints, double ratio, int fill)
+_giza_star (double x, double y, int npoints, double ratio, int fill, double scale)
 {
  /* Define outer and inner radius */
- double r = 0.5 * markerHeight;
+ double r = 0.5 * markerHeight * scale;
  double ri = ratio * r;
 
  /* Set first vertex so that shape appears flat-bottomed */
  double alpha = (0.5 + 1./npoints)* M_PI;
  double cosalpha = cos(alpha);
  double sinalpha = sin(alpha);
- cairo_move_to (Dev[id].context, x + r * cosalpha, y + r * sinalpha);
-
  /* Define other vertexes */
  double alpha_step = 2 * M_PI / npoints;
  int i;
+
+ cairo_save( Dev[id].context );
+ /* Use slightly thinner lines */
+ cairo_set_line_width( Dev[id].context, 0.9 );
+ cairo_move_to (Dev[id].context, x + r * cosalpha, y + r * sinalpha);
+
  for (i = 1; i < npoints; i++)
  {
   alpha += 0.5*alpha_step;
@@ -666,7 +668,9 @@ _giza_star (double x, double y, int npoints, double ratio, int fill)
  cairo_line_to (Dev[id].context, x + ri * cosalpha, y + ri * sinalpha);
  cairo_close_path(Dev[id].context);
  if (fill) { cairo_fill(Dev[id].context); }
-  _giza_stroke ();
+
+ cairo_stroke ( Dev[id].context );
+ cairo_restore( Dev[id].context );
 
 }
 

--- a/src/giza-points.c
+++ b/src/giza-points.c
@@ -38,6 +38,7 @@ static void _giza_point        (double x, double y);
 static void _giza_rect         (double x, double y, int fill);
 static void _giza_rect_concave (double x, double y, int fill, double scale, double bulge_fraction);
 static void _giza_plus         (double x, double y);
+static void _giza_fat_plus     (double x, double y, int fill, double scale, double inset_fraction);
 static void _giza_triangle     (double x, double y, int fill, int updown, float scale, float offset_fraction);
 static void _giza_diamond      (double x, double y, int fill);
 static void _giza_polygon      (double x, double y, int nsides , int fill);
@@ -336,8 +337,8 @@ _giza_draw_symbol (double xd, double yd, int symbol)
           _giza_triangle(xd, yd, 0, GIZA_POINT_UP,   0.7, 0.5);
           _giza_triangle(xd, yd, 0, GIZA_POINT_DOWN, 0.7, 0.5);
           break;
-        case 14: /* pentagon */
-          _giza_polygon (xd, yd, 5, 0);
+        case 14: /* open plus sign */
+          _giza_fat_plus(xd, yd, 0, 2.2, 0.5);
           break;
         case 13: /* solid triangle */
           _giza_triangle(xd, yd, 1, GIZA_POINT_UP, 0.7, 1);
@@ -465,6 +466,41 @@ _giza_plus (double x, double y)
   cairo_move_to (Dev[id].context, x, y - markerHeight * 0.5);
   cairo_line_to (Dev[id].context, x, y + markerHeight * 0.5);
   _giza_stroke ();
+}
+
+
+/**
+ * Draw a 'fat' plus centred at x, y
+ * principal size = 0.5 * markerHeigth,
+ * this symbol's real size = principal size scaled by 'scale'
+ * The insets are inset_fraction * real size
+ */
+static void
+_giza_fat_plus (double x, double y, int fill, double scale, double inset_fraction)
+{
+  const double side  = 0.5 * markerHeight * scale;
+  const double inset = inset_fraction * side, outset = side - inset;
+
+  /* Use slightly thinner lines than the other symbols */
+  cairo_save( Dev[id].context );
+  cairo_set_line_width( Dev[id].context, 0.8 );
+
+  cairo_move_to     (Dev[id].context, x - side, y - outset/2);
+  cairo_rel_line_to (Dev[id].context, 0       , outset); /* up */
+  cairo_rel_line_to (Dev[id].context, inset   , 0);      /* right */
+  cairo_rel_line_to (Dev[id].context, 0       , inset);  /* up */
+  cairo_rel_line_to (Dev[id].context, outset  , 0);      /* right */
+  cairo_rel_line_to (Dev[id].context, 0       , -inset); /* down */
+  cairo_rel_line_to (Dev[id].context, inset   , 0);      /* right */
+  cairo_rel_line_to (Dev[id].context, 0       , -outset);/* down */
+  cairo_rel_line_to (Dev[id].context, -inset  , 0);      /* left */
+  cairo_rel_line_to (Dev[id].context, 0       , -inset); /* down */
+  cairo_rel_line_to (Dev[id].context, -outset , 0);      /* left */
+  cairo_rel_line_to (Dev[id].context, 0       , inset);  /* up */
+  cairo_rel_line_to (Dev[id].context, -inset  , 0);      /* left */
+  if (fill) { cairo_fill(Dev[id].context); }
+  cairo_stroke(  Dev[id].context );
+  cairo_restore( Dev[id].context );
 }
 
 /**


### PR DESCRIPTION
This is an attempt at resolving the symbol issues raised in @karlgrazebrook's [Issue](https://github.com/danieljprice/giza/issues/5).

I attach a screenshot of how pgdemo2, 2nd screen renders on my system. Compare to [the differences shown here](https://github.com/danieljprice/giza/issues/5#issuecomment-436071847).

I think that there are a few other symbols that could do with a bit of scaling up - but let's check these ones first.

![screen shot 2018-11-08 at 15 40 28](https://user-images.githubusercontent.com/14309703/48205512-a6403900-e36c-11e8-8818-786531e8a33e.png)
