### PR TITLE
Avoid compilation errors with Splash

### DIFF
--- a/src/giza-box-time.c
+++ b/src/giza-box-time.c
@@ -134,9 +134,11 @@ int _giza_npl(int nmax, int n) {
   }
   /* Now that we have a copy of the strings we can easily upcase them -
      makes parsing easier */
-  for(char* px = xopt_cp; *px; px++ )
+  char* px;
+  for(px = xopt_cp; *px; px++ )
       *px = toupper(*px);
-  for(char* py = yopt_cp; *py; py++ )
+  char* py;
+  for(py = yopt_cp; *py; py++ )
       *py = toupper(*py);
 
   /* X-axis */

--- a/src/giza-colour-palette.c
+++ b/src/giza-colour-palette.c
@@ -162,6 +162,24 @@ giza_set_colour_palette (int palette)
        giza_set_colour_representation_rgb (8, 139, 94, 45); /* brown */
        nlinecolours = 9;
        break;
+    case 8: /* Matlab inspired colours */
+       giza_set_colour_representation_rgb( 2,   0,  114, 189);
+       giza_set_colour_representation_rgb( 3,  217,  83,  25);
+       giza_set_colour_representation_rgb( 4,  237, 177,  32);
+       giza_set_colour_representation_rgb( 5,  126,  47, 142);
+       giza_set_colour_representation_rgb( 6,  119, 172,  48);
+       giza_set_colour_representation_rgb( 7,   77, 190, 238);
+       giza_set_colour_representation_rgb( 8,  162,  20,  47);
+       giza_set_colour_representation_rgb( 9,   95, 158, 160);
+       giza_set_colour_representation_rgb(10,  238, 203, 173);
+       giza_set_colour_representation_rgb(11,  190, 179, 239);
+       giza_set_colour_representation_rgb(12, 0.35, 0.7, 0.9);
+       giza_set_colour_representation_rgb(13,   0., 0.6, 0.5);
+       giza_set_colour_representation_rgb(14,  0.8, 0.4,  0.);
+       giza_set_colour_representation_rgb(15,  0.8, 0.6, 0.7);
+       giza_set_colour_representation_rgb(16,  160, 160, 160);
+       nlinecolours = 16;
+       break;
     default:
        giza_set_colour_representation (0, 1., 1., 1.);	/* white */
        giza_set_colour_representation (1, 0., 0., 0.);	/* black */

--- a/src/giza-drivers.c
+++ b/src/giza-drivers.c
@@ -135,7 +135,8 @@ giza_open_device_size (const char *newDeviceName, const char *newPrefix, double 
   static int didInit = 0;
 
   if( !didInit ) {
-      for(giza_device_t* pDev = &Dev[0]; pDev < &Dev[GIZA_MAX_DEVICES]; pDev++)
+	  giza_device_t* pDev;
+      for(pDev = &Dev[0]; pDev < &Dev[GIZA_MAX_DEVICES]; pDev++)
           _giza_init_device_struct( pDev );
        didInit = 1;
   }
@@ -527,7 +528,8 @@ giza_close_device (void)
   /* if no open devices remain, force-unload the font cache.
    * it will be rebuilt as soon as new devices will be opened */
   unsigned int nOpen = 0;
-  for(giza_device_t* p=&Dev[0]; p<&Dev[GIZA_MAX_DEVICES]; p++)
+  giza_device_t* p;
+  for(p=&Dev[0]; p<&Dev[GIZA_MAX_DEVICES]; p++)
       if( p->deviceOpen )
           nOpen++;
   if( nOpen==0 )


### PR DESCRIPTION
When checking out Splash for the first time, compilation fails because there are some for loops that require the C99 compiler flag. I have defined these variables outside the for loop to avoid the compilation error.

I have also added my favourite colour palette.