### PR TITLE
For PNG images sometimes the internal logic would classify a single page

### DIFF
--- a/src/giza-driver-png.c
+++ b/src/giza-driver-png.c
@@ -121,25 +121,27 @@ _giza_change_page_png (void)
 void
 _giza_close_device_png (int last)
 {
-  if( Dev[id].surface==NULL )
+  if( Dev[id].surface==NULL ) {
       return;
-  int lenext = strlen (GIZA_DEVICE_EXTENSION);
-  int length = strlen (Dev[id].prefix) + lenext + 5;
-  char fileName[length + 1];
-  _giza_get_filename_for_device(fileName,Dev[id].prefix,Dev[id].pgNum,GIZA_DEVICE_EXTENSION,last);
-
-  cairo_status_t status = cairo_surface_write_to_png (Dev[id].surface, fileName);
-  if (status != CAIRO_STATUS_SUCCESS)
-     {
-       _giza_error (fileName, cairo_status_to_string(status));
-     }
-  else
-     {
-       char tmp[length + 10];
-       sprintf(tmp, "%s created", fileName);
-       _giza_message (tmp);
-     }
-
+  }
+  if (Dev[id].drawn) 
+    { 
+      int lenext = strlen (GIZA_DEVICE_EXTENSION);
+      int length = strlen (Dev[id].prefix) + lenext + 5;
+      char fileName[length + 1];
+      _giza_get_filename_for_device(fileName,Dev[id].prefix,Dev[id].pgNum,GIZA_DEVICE_EXTENSION,last);
+      cairo_status_t status = cairo_surface_write_to_png (Dev[id].surface, fileName);
+      if (status != CAIRO_STATUS_SUCCESS) 
+        {
+          _giza_error (fileName, cairo_status_to_string(status));
+        }
+/*    else
+       {
+         char tmp[length + 10];
+         sprintf(tmp, "%s created", fileName);
+         _giza_message (tmp);
+       }*/
+    }
   cairo_surface_destroy (Dev[id].surface);
 }
 

--- a/src/giza-drivers.c
+++ b/src/giza-drivers.c
@@ -471,7 +471,9 @@ giza_change_page (void)
       return;
     }
 
-  Dev[id].pgNum++;
+  /* Only increase pagenumber if there was content */
+  if (Dev[id].drawn)
+      Dev[id].pgNum++;
 
   /* Reset stuff */
   giza_set_panel(1,1); /* also calls set_viewport */
@@ -1135,7 +1137,6 @@ void _giza_trim(char *str) {
 void _giza_get_filename_for_device (char *filename, char *prefix, int pgNum, char *extension,
                                     int lastpage)
 {
-
   /* this stuff is instead of using strcasestr
    * (giza should not use non-standard extensions)
    */


### PR DESCRIPTION
plot as a multi-page plot, multi-page plots have a different file naming
convention; the sole effect of this bug is that the filename will be
different then expected.

PGPLOT doesn't have this behaviour, so this bug will cause issues when using
GIZA as a drop-in replacement for PGPLOT.