### PR TITLE
Motion callback

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -4,7 +4,7 @@ CLEANFILES = *.mod *.pc
 
 lib_LTLIBRARIES = libgiza.la libcpgplot.la libpgplot.la
 
-libgiza_la_SOURCES = giza-annotate.c giza-arrow-style.c giza-arrow.c \
+libgiza_la_SOURCES = giza-annotate.c giza-arrow-style.c giza-arrow.c giza-axis.c \
        giza-band-style.c giza-band.c giza-box-time.c giza-box.c \
        giza-buffering.c giza-character-size.c giza-circle.c \
        giza-clipping.c giza-colour-bar.c giza-colour-index.c \

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -147,11 +147,12 @@ libcpgplot_la_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) \
 libgiza_la_LIBADD =
 am_libgiza_la_OBJECTS = libgiza_la-giza-annotate.lo \
 	libgiza_la-giza-arrow-style.lo libgiza_la-giza-arrow.lo \
-	libgiza_la-giza-band-style.lo libgiza_la-giza-band.lo \
-	libgiza_la-giza-box-time.lo libgiza_la-giza-box.lo \
-	libgiza_la-giza-buffering.lo libgiza_la-giza-character-size.lo \
-	libgiza_la-giza-circle.lo libgiza_la-giza-clipping.lo \
-	libgiza_la-giza-colour-bar.lo libgiza_la-giza-colour-index.lo \
+	libgiza_la-giza-axis.lo libgiza_la-giza-band-style.lo \
+	libgiza_la-giza-band.lo libgiza_la-giza-box-time.lo \
+	libgiza_la-giza-box.lo libgiza_la-giza-buffering.lo \
+	libgiza_la-giza-character-size.lo libgiza_la-giza-circle.lo \
+	libgiza_la-giza-clipping.lo libgiza_la-giza-colour-bar.lo \
+	libgiza_la-giza-colour-index.lo \
 	libgiza_la-giza-colour-palette.lo \
 	libgiza_la-giza-colour-table.lo libgiza_la-giza-contour.lo \
 	libgiza_la-giza-cursor-routines.lo \
@@ -210,6 +211,7 @@ am__depfiles_remade = ./$(DEPDIR)/libcpgplot_la-giza-cpgplot.Plo \
 	./$(DEPDIR)/libgiza_la-giza-annotate.Plo \
 	./$(DEPDIR)/libgiza_la-giza-arrow-style.Plo \
 	./$(DEPDIR)/libgiza_la-giza-arrow.Plo \
+	./$(DEPDIR)/libgiza_la-giza-axis.Plo \
 	./$(DEPDIR)/libgiza_la-giza-band-style.Plo \
 	./$(DEPDIR)/libgiza_la-giza-band.Plo \
 	./$(DEPDIR)/libgiza_la-giza-box-time.Plo \
@@ -491,7 +493,7 @@ top_builddir = @top_builddir@
 top_srcdir = @top_srcdir@
 CLEANFILES = *.mod *.pc
 lib_LTLIBRARIES = libgiza.la libcpgplot.la libpgplot.la
-libgiza_la_SOURCES = giza-annotate.c giza-arrow-style.c giza-arrow.c \
+libgiza_la_SOURCES = giza-annotate.c giza-arrow-style.c giza-arrow.c giza-axis.c \
        giza-band-style.c giza-band.c giza-box-time.c giza-box.c \
        giza-buffering.c giza-character-size.c giza-circle.c \
        giza-clipping.c giza-colour-bar.c giza-colour-index.c \
@@ -633,6 +635,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/libgiza_la-giza-annotate.Plo@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/libgiza_la-giza-arrow-style.Plo@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/libgiza_la-giza-arrow.Plo@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/libgiza_la-giza-axis.Plo@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/libgiza_la-giza-band-style.Plo@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/libgiza_la-giza-band.Plo@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/libgiza_la-giza-box-time.Plo@am__quote@ # am--include-marker
@@ -765,6 +768,13 @@ libgiza_la-giza-arrow.lo: giza-arrow.c
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='giza-arrow.c' object='libgiza_la-giza-arrow.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libgiza_la_CPPFLAGS) $(CPPFLAGS) $(AM_CFLAGS) $(CFLAGS) -c -o libgiza_la-giza-arrow.lo `test -f 'giza-arrow.c' || echo '$(srcdir)/'`giza-arrow.c
+
+libgiza_la-giza-axis.lo: giza-axis.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libgiza_la_CPPFLAGS) $(CPPFLAGS) $(AM_CFLAGS) $(CFLAGS) -MT libgiza_la-giza-axis.lo -MD -MP -MF $(DEPDIR)/libgiza_la-giza-axis.Tpo -c -o libgiza_la-giza-axis.lo `test -f 'giza-axis.c' || echo '$(srcdir)/'`giza-axis.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) $(DEPDIR)/libgiza_la-giza-axis.Tpo $(DEPDIR)/libgiza_la-giza-axis.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='giza-axis.c' object='libgiza_la-giza-axis.lo' libtool=yes @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libgiza_la_CPPFLAGS) $(CPPFLAGS) $(AM_CFLAGS) $(CFLAGS) -c -o libgiza_la-giza-axis.lo `test -f 'giza-axis.c' || echo '$(srcdir)/'`giza-axis.c
 
 libgiza_la-giza-band-style.lo: giza-band-style.c
 @am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libgiza_la_CPPFLAGS) $(CPPFLAGS) $(AM_CFLAGS) $(CFLAGS) -MT libgiza_la-giza-band-style.lo -MD -MP -MF $(DEPDIR)/libgiza_la-giza-band-style.Tpo -c -o libgiza_la-giza-band-style.lo `test -f 'giza-band-style.c' || echo '$(srcdir)/'`giza-band-style.c
@@ -1432,6 +1442,7 @@ distclean: distclean-am
 	-rm -f ./$(DEPDIR)/libgiza_la-giza-annotate.Plo
 	-rm -f ./$(DEPDIR)/libgiza_la-giza-arrow-style.Plo
 	-rm -f ./$(DEPDIR)/libgiza_la-giza-arrow.Plo
+	-rm -f ./$(DEPDIR)/libgiza_la-giza-axis.Plo
 	-rm -f ./$(DEPDIR)/libgiza_la-giza-band-style.Plo
 	-rm -f ./$(DEPDIR)/libgiza_la-giza-band.Plo
 	-rm -f ./$(DEPDIR)/libgiza_la-giza-box-time.Plo
@@ -1547,6 +1558,7 @@ maintainer-clean: maintainer-clean-am
 	-rm -f ./$(DEPDIR)/libgiza_la-giza-annotate.Plo
 	-rm -f ./$(DEPDIR)/libgiza_la-giza-arrow-style.Plo
 	-rm -f ./$(DEPDIR)/libgiza_la-giza-arrow.Plo
+	-rm -f ./$(DEPDIR)/libgiza_la-giza-axis.Plo
 	-rm -f ./$(DEPDIR)/libgiza_la-giza-band-style.Plo
 	-rm -f ./$(DEPDIR)/libgiza_la-giza-band.Plo
 	-rm -f ./$(DEPDIR)/libgiza_la-giza-box-time.Plo

--- a/src/giza-axis.c
+++ b/src/giza-axis.c
@@ -1,0 +1,374 @@
+/* giza - a scientific plotting library built on cairo
+ *
+ * Copyright (c) 2010      James Wetter and Daniel Price
+ * Copyright (c) 2010-2022 Daniel Price
+ *
+ * This library is free software; and you are welcome to redistribute
+ * it under the terms of the GNU General Public License
+ * (GPL, see LICENSE file for details) and the provision that
+ * this notice remains intact. If you modify this file, please
+ * note section 2a) of the GPLv2 states that:
+ *
+ *  a) You must cause the modified files to carry prominent notices
+ *     stating that you changed the files and the date of any change.
+ *
+ * This software is distributed "AS IS", with ABSOLUTELY NO WARRANTY.
+ * See the GPL for specific language governing rights and limitations.
+ *
+ * The Original code is the giza plotting library.
+ *
+ * Contributor(s):
+ *      James Wetter <wetter.j@gmail.com>
+ *      Daniel Price <daniel.price@monash.edu> (main contact)
+ */
+
+#include "giza-private.h"
+#include "giza-transforms-private.h"
+#include "giza-io-private.h"
+#include "giza-stroke-private.h"
+#include "giza-window-private.h"
+#include "giza-viewport-private.h"
+#include "giza-drivers-private.h"
+#include <giza.h>
+#include <math.h>
+#include <stdio.h>
+
+/**
+ * Drawing: giza_axis
+ *
+ * Synopsis: Draw a labelled axis from (x1,y1) to (x2,y2)
+ *
+ * Input:
+ *  -opt  :- String of options for the axis.
+ *           The options may be in any order. See
+ *           below for details
+ *  -x1   :- starting x position in world coordinates
+ *  -y1   :- starting y position in world coordinates
+ *  -x2   :- finishing x position in world coordinates
+ *  -y2   :- finishing y position in world coordinates
+ *  -v1   :- axis value at starting position
+ *  -v2   :- axis value at finishing position
+ *  -tick :- The distance, in world coordinates,
+ *            between major ticks on the axis.
+ *            If 0.0 the interval is chosen
+ *            automatically.
+ *  -nsub :- The number of minor ticks to be placed
+ *            between each major tick. If 0 the
+ *            number is chosen automatically. Ignored if log axis.
+ *  -dmajl :- Length of major tick marks drawn to "left/bottom" of axis
+ *             in units of character height
+ *  -dmajr :- Length of major tick marks drawn to "right/top" of axis
+ *             in units of character height
+ *  -fmin  :- Length of minor tick marks as fraction of major
+ *  -disp  :- Displacement of labels from axis
+ *             in units of character height
+ *  -angle :- Label orientation; angle between text and direction of axis; in degrees
+ *
+ * Options:
+ *  -T :- Draw major ticks.
+ *  -S :- Draw minor ticks.
+ *  -N :- Label the axis
+ *  -L :- Label axis logarithmically
+ *  -H :- Hide the axis (draw ticks only)
+ *  -I :- 'Invert' tick marks, draw them on opposite side
+ *  -1 :- Force decimal labelling instead of automatic choice (see giza_format_number)
+ *  -2 :- Force exponential labelling instead of automatic choice (see giza_format_number)
+ */
+void
+giza_axis (const char *opt, double x1, double y1, double x2, double y2,
+          double v1, double v2, double tick, int nsub,
+          double dmajl, double dmajr, double fmin, double disp, double angle)
+{
+  if (!_giza_check_device_ready ("giza_axis"))
+    return;
+
+  _giza_expand_clipping ();
+
+  int oldBuf;
+  giza_get_buffering(&oldBuf);
+
+  /* Table of log10() values for log axis ticks */
+  double logTab[9];
+  int k;
+  for (k = 0; k < 9; k++)
+    {
+      logTab[k] = log10 (k + 1);
+    }
+
+  /* Begin buffering */
+  giza_begin_buffer ();
+
+  int draw_majticks = 0, draw_minticks = 0, draw_labels = 0,
+      draw_log = 0, draw_invert = -1, draw_axis = 1;
+
+  int number_format = Dev[id].number_format;
+
+  double intervalMaj, intervalMin, val, ratio;
+  int nv, np;
+  int nMinTicks, major;
+  double majTickL_l, subTickL_l, currentTickL_l;
+  double majTickL_r, subTickL_r, currentTickL_r;
+  char tmp[100];
+  int i, i1, i2, j, jmax, jtmp;
+  double x,y,xpt,ypt,theta,theta_deg,dr;
+
+  theta = atan2(y2-y1,x2-x1);
+  theta_deg = theta / GIZA_DEG_TO_RAD;
+  dr = sqrt(pow(x2-x1,2) + pow(y2-y1,2));
+
+  cairo_matrix_t mat;
+  cairo_matrix_init_translate(&mat,x1,y1);
+  cairo_matrix_rotate(&mat,theta);
+
+  /* set x-options */
+  for (i = 0; opt[i]; i++)
+    {
+    switch (opt[i])
+      {
+      case ('h'):
+      case ('H'):
+	     draw_axis = 0;
+        break;
+      case ('t'):
+      case ('T'):
+        draw_majticks = 1;
+        break;
+      case ('s'):
+      case ('S'):
+        draw_minticks = 1;
+        break;
+          /* Any of nmNM means labels need to be drawn. mM says to do so unconventionally. */
+      case ('n'):
+      case ('N'):
+        draw_labels = 1;
+        break;
+      case ('l'):
+      case ('L'):
+        draw_log = 1;
+        break;
+      case ('i'):
+      case ('I'):
+        draw_invert = 1;
+        break;
+      case ('1'):
+        number_format = GIZA_NUMBER_FORMAT_DEC;
+        break;
+      case ('2'):
+        number_format = GIZA_NUMBER_FORMAT_EXP;
+        break;
+      default:
+        break;
+      }
+    }
+
+  int oldTrans = _giza_get_trans ();
+  _giza_set_trans (GIZA_TRANS_WORLD);
+
+  double xch, ych;
+  giza_get_character_size (GIZA_UNITS_WORLD, &xch, &ych);
+
+  /* draw the line */
+  if (draw_axis)
+    {
+      cairo_move_to (Dev[id].context, x1, y1);
+      cairo_line_to (Dev[id].context, x2, y2);
+    }
+
+  /* set major tick length in pixels */
+  majTickL_l = Dev[id].fontExtents.max_x_advance * dmajl;
+  majTickL_r = Dev[id].fontExtents.max_x_advance * dmajr;
+  subTickL_l = 0.;
+  subTickL_r = 0.;
+
+  /* convert to world coords */
+  cairo_device_to_user_distance (Dev[id].context, &subTickL_l, &majTickL_l);
+  cairo_device_to_user_distance (Dev[id].context, &subTickL_r, &majTickL_r);
+  majTickL_l = -majTickL_l;
+  majTickL_r = -majTickL_r;
+
+  /* set minor tick length as a fraction of the major tick length */
+  subTickL_l = majTickL_l * fmin;
+  subTickL_r = majTickL_r * fmin;
+
+  /* Choose x tick intervals */
+  if (draw_log)
+    {
+      nMinTicks = 1;
+      intervalMaj = 1.;
+    }
+  else if (_giza_equal(tick,0.))
+    {
+      intervalMaj = 7. * Dev[id].fontExtents.max_x_advance /
+        ((Dev[id].VP.xmax - Dev[id].VP.xmin)*Dev[id].width);
+      if (intervalMaj > 0.2)
+	      intervalMaj = 0.2;
+      if (intervalMaj < 0.05)
+	      intervalMaj = 0.05;
+      intervalMaj = intervalMaj * (v2 - v1);
+      intervalMaj = giza_round (intervalMaj, &nMinTicks);
+    }
+  else
+    {
+      intervalMaj = tick;
+      nMinTicks = nsub;
+      if (nsub < 1 || !draw_minticks) nMinTicks = 1;
+    }
+  intervalMin = intervalMaj / (double) nMinTicks;
+
+  /* Only enter tick drawing if (1) any of the ticks/grid must be drawn AND
+     (2) at least one of top, bottom or axis must be drawn because the ticks
+     can only be drawn on any/all of these lines */
+  if (draw_majticks || draw_minticks)
+    {
+      _giza_tick_intervals (v1, v2, intervalMin, &i1, &i2);
+      jmax = 0;
+      /* If log axis ticks always have 9 minor ticks */
+      if (draw_log) jmax = 8;
+
+      for (i = i1; i <= i2; i++)
+        {
+          for (j = 0; j <= jmax; j++)
+            {
+              /* log axis ticks are major when j = 0 */
+              major = (i % nMinTicks == 0) && draw_majticks && (j == 0);
+              currentTickL_l = subTickL_l;
+              currentTickL_r = subTickL_r;
+              if (major)
+                 {
+                 currentTickL_l = majTickL_l;
+                 currentTickL_r = majTickL_r;
+                 }
+              val = (i + logTab[j]) * intervalMin;
+              ratio = (val - v1) / (v2 - v1);
+
+              /* don't draw over axis or outside the box */
+              if ((i == 0) || (val >= v2) || (val <= v1))
+                continue;
+              /* are we supposed to draw this tick anyway? */
+              if ( !((major && draw_majticks) || draw_minticks) )
+                continue;
+
+              /* set location of tick start and end in non-rotated coords */
+              x   = dr * ratio;
+              xpt = x;
+              y   = -currentTickL_l;
+              ypt = currentTickL_r;
+
+              /* rotate and translate */
+              cairo_matrix_transform_point (&mat,&x,&y);
+              cairo_matrix_transform_point (&mat,&xpt,&ypt);
+
+              /* draw the tick(s) along the axis */
+              cairo_move_to (Dev[id].context, x, y);
+              cairo_line_to (Dev[id].context, xpt, ypt);
+
+            }
+        }
+      _giza_stroke ();
+    }
+
+  /* labels */
+  if (draw_labels)
+    {
+      _giza_tick_intervals (v1, v2, intervalMaj, &i1, &i2);
+      np = (int) floor (log10 (fabs (intervalMaj)));
+      nv = _giza_nint (intervalMaj/pow (10., np));
+
+      for (i = i1; i <= i2; i++)
+	     {
+	       val = i * intervalMaj;
+	       ratio = (val - v1) / (v2 - v1);
+          /* don't draw label if outside frame */
+	       if (ratio < 0. || ratio > 1.)
+             continue;
+          if (draw_log)
+            {
+              jtmp = _giza_nint(val);
+              if (jtmp == 1) {
+                 sprintf (tmp, "10");
+              } else if (jtmp == 0) {
+                 sprintf (tmp, "1");
+              } else {
+                 sprintf (tmp, "10^{%i}", jtmp);
+              }
+            }
+          else
+            {
+              giza_format_number (i*nv, np, number_format, tmp, sizeof(tmp));
+            }
+
+          /* write the label */
+          x = dr * ratio;
+          y = ych * disp;
+          cairo_matrix_transform_point (&mat,&x,&y);
+          giza_ptext (x, y, theta_deg + angle, 0.5, tmp);
+
+	}
+      _giza_stroke ();
+    }
+
+  /* extra labels for log axis */
+  if (draw_labels && draw_log && (v2 - v1 < 2.))
+    {
+      _giza_tick_intervals (v1, v2, intervalMin, &i1, &i2);
+      for (i = i1 - 1; i <= i2; i++)
+	     {
+	     for (j = 1; j <= 4; j += 3)
+	       {
+	         val = (i + logTab[j]) * intervalMin;
+	         if (val <= v2 && val >= v1)
+              {
+		        ratio = (val - v1) / (v2 - v1);
+		        val = pow (10, val);
+		        giza_format_number (j+1, _giza_nint (i * intervalMin), number_format, tmp, sizeof(tmp));
+
+              /* write the label */
+              x = dr * ratio;
+              y = ych * disp;
+              cairo_matrix_transform_point (&mat,&x,&y);
+              giza_ptext (x, y, theta_deg + angle, 0.5, tmp);
+              }
+           }
+        }
+    }
+
+  /* stroke all the paths */
+  int lc;
+  giza_get_line_cap (&lc);
+  giza_set_line_cap (CAIRO_LINE_CAP_SQUARE);
+  _giza_stroke ();
+  giza_set_line_cap (lc);
+  _giza_set_trans (oldTrans);
+
+  /* end buffer if it was not on before this function call */
+  if (!oldBuf)
+    {
+      giza_end_buffer ();
+    }
+
+  giza_flush_device ();
+
+  /* Restore clipping */
+  giza_set_viewport (Dev[id].VP.xmin, Dev[id].VP.xmax, Dev[id].VP.ymin, Dev[id].VP.ymax);
+}
+
+/**
+ * Drawing: giza_axis_float
+ *
+ * Synopsis: Same functionality as giza_axis but takes floats instead of doubles.
+ *
+ * See Also: giza_axis
+ */
+void
+giza_axis_float (const char *opt, float x1, float y1, float x2, float y2,
+          float v1, float v2, float step, int nsub,
+          float dmajl, float dmajr, float fmin, float disp, float angle)
+{
+  if (!_giza_check_device_ready ("giza_axis"))
+    return;
+
+  giza_axis(opt, (double) x1, (double) y1, (double) x2, (double) y2,
+          (double) v1, (double) v2, (double) step, nsub,
+          (double) dmajl, (double) dmajr, (double) fmin, (double) disp, (double) angle);
+
+}

--- a/src/giza-band.c
+++ b/src/giza-band.c
@@ -45,8 +45,8 @@ giza_band_t Band;
  *               if 0 the cursor is not moved.
  *  -xanc     :- the x-coord of the anchor point.
  *  -yanc     :- the y-coord of the anchor point.
- *  -x        :- Gets set the position of the cursor.
- *  -y        :- Gets set to the position of the cursor.
+ *  -x        :- Gets set to the x position of the cursor.
+ *  -y        :- Gets set to the y position of the cursor.
  *  -ch       :- Gets set to the character pressed by the user.
  *
  * Return:
@@ -140,7 +140,7 @@ _giza_refresh_band (int mode, int nanc, const int *xanc, const int *yanc, int x2
   int x1 = xanc[nanc-1];
   int y1 = yanc[nanc-1];
   int i,j;
- 
+
   switch (mode)
     {
       case 1: /* Straight line */
@@ -149,7 +149,7 @@ _giza_refresh_band (int mode, int nanc, const int *xanc, const int *yanc, int x2
            if (j==0) {
               cairo_set_source_rgba (Band.box,1.,1.,1.,0.2);
            } else {
-              cairo_set_source_rgba (Band.box, 0.6, 0.6, 0.6, 1.0);           
+              cairo_set_source_rgba (Band.box, 0.6, 0.6, 0.6, 1.0);
            }
 	   cairo_move_to (Band.box, xanc[0], yanc[0]);
            for (i=1;i<=nanc-1;i++) {
@@ -235,4 +235,3 @@ _giza_destroy_band (int mode)
   /* remove the last band */
   giza_flush_device ();
 }
-

--- a/src/giza-box.c
+++ b/src/giza-box.c
@@ -33,9 +33,6 @@
 #include <math.h>
 #include <stdio.h>
 
-static void _giza_tick_intervals (double xmin, double xmax, double xinterval,
-				  int *i1, int *i2);
-
 /**
  * Drawing: giza_box
  *
@@ -76,7 +73,7 @@ static void _giza_tick_intervals (double xmin, double xmax, double xinterval,
  */
 void
 giza_box (const char *xopt, double xtick, int nxsub,
-	  const char *yopt, double ytick, int nysub)
+          const char *yopt, double ytick, int nysub)
 {
   if (!_giza_check_device_ready ("giza_box"))
     return;
@@ -270,7 +267,7 @@ giza_box (const char *xopt, double xtick, int nxsub,
   else if (_giza_equal(xtick,0.))
     {
       xintervalMaj =
-	7. * Dev[id].fontExtents.max_x_advance / 
+	7. * Dev[id].fontExtents.max_x_advance /
         ((Dev[id].VP.xmax - Dev[id].VP.xmin)*Dev[id].width);
       if (xintervalMaj > 0.2)
 	xintervalMaj = 0.2;
@@ -426,7 +423,7 @@ giza_box (const char *xopt, double xtick, int nxsub,
   else if (_giza_equal(ytick,0.))
     {
       yintervalMaj =
-	7. * Dev[id].fontExtents.max_x_advance / 
+	7. * Dev[id].fontExtents.max_x_advance /
         ((Dev[id].VP.ymax - Dev[id].VP.ymin) * Dev[id].height);
       if (yintervalMaj > 0.2) yintervalMaj = 0.2;
       if (yintervalMaj < 0.05) yintervalMaj = 0.05;
@@ -525,7 +522,7 @@ giza_box (const char *xopt, double xtick, int nxsub,
               giza_format_number (i*nv, np, Dev[id].number_format, tmp, sizeof(tmp));
             }
 
-          if (ylabel_unconventional) 
+          if (ylabel_unconventional)
             {
               if (ydraw_vertical)
                 giza_annotate ("RV", .7, yratio, 0., tmp);
@@ -557,7 +554,7 @@ giza_box (const char *xopt, double xtick, int nxsub,
 		  yval = pow (10, yval);
 		  giza_format_number (j+1, _giza_nint (i*yintervalMin), Dev[id].number_format, tmp, sizeof(tmp));
 
-                  if (ylabel_unconventional) 
+                  if (ylabel_unconventional)
                     {
                       if (ydraw_vertical)
                         giza_annotate ("RV", .7, yratio, 0., tmp);
@@ -658,7 +655,7 @@ giza_box_float (const char *xopt, float xtick, int nxsub,
 /**
  * Works out which intervals in which to draw ticks.
  */
-static void
+void
 _giza_tick_intervals (double xmin, double xmax, double xinterval, int *i1,
 		      int *i2)
 {

--- a/src/giza-box.c
+++ b/src/giza-box.c
@@ -148,7 +148,7 @@ giza_box (const char *xopt, double xtick, int nxsub,
 	case ('S'):
 	  xdraw_minticks = 1;
 	  break;
-        /* Any of nmNM means labels need to be drawn. mM sais to do so unconventionally. */
+        /* Any of nmNM means labels need to be drawn. mM says to do so unconventionally. */
 	case ('n'):
 	case ('m'):
 	case ('N'):
@@ -204,7 +204,7 @@ giza_box (const char *xopt, double xtick, int nxsub,
 	case ('S'):
 	  ydraw_minticks = 1;
 	  break;
-        /* Any of nmNM means labels need to be drawn. mM sais to do so unconventionally. */
+        /* Any of nmNM means labels need to be drawn. mM says to do so unconventionally. */
 	case ('n'):
 	case ('m'):
 	case ('N'):
@@ -239,10 +239,10 @@ giza_box (const char *xopt, double xtick, int nxsub,
   /* Note: -P :- extend ("Project") major tick marks outside the box (ignored if
                  option I is specified).
     In this code: invert<0 is default so >0 means option was specified */
-  if( xdraw_invert>0 )
-    xdraw_project = 0;
-  if( ydraw_invert>0 )
-    ydraw_project = 0;
+  if ( xdraw_invert>0 )
+     xdraw_project = 0;
+  if ( ydraw_invert>0 )
+     ydraw_project = 0;
 
   int oldTrans = _giza_get_trans ();
   _giza_set_trans (GIZA_TRANS_WORLD);

--- a/src/giza-character-size.c
+++ b/src/giza-character-size.c
@@ -31,6 +31,8 @@
  * Settings: giza_set_character_height
  *
  * Synopsis: Sets the font size in units of character height.
+ *           A character height of 1.0 corresponds to 1/37th
+ *           of the plotting surface height by default
  *
  * Input:
  *  -ch :- the new character height
@@ -114,6 +116,8 @@ giza_get_character_height_float (float *ch)
  *
  * Input:
  *  -units  :- select the units the result will be returned in.
+ *
+ * Output:
  *  -width  :- will be set to the width of a character.
  *  -height :- will be set to the height of a character.
  *

--- a/src/giza-driver-xw-private.h
+++ b/src/giza-driver-xw-private.h
@@ -30,7 +30,8 @@ void _giza_flush_device_xw (void);
 void _giza_change_page_xw (void);
 void _giza_close_device_xw (void);
 void _giza_expand_clipping_xw (void);
-void _giza_get_key_press_xw (int mode, int moveCurs, int nanc, const double *xanc, const double *yanch, 
+void _giza_reset_clipping_xw (void);
+void _giza_get_key_press_xw (int mode, int moveCurs, int nanc, const double *xanc, const double *yanch,
                              double *x, double *y, char *ch);
 int _giza_init_band_xw (void);
 int _giza_select_xw(int devid);

--- a/src/giza-driver-xw.c
+++ b/src/giza-driver-xw.c
@@ -377,6 +377,7 @@ _giza_xevent_loop (int mode, int moveCurs, int nanc, const int *anchorx, const i
   XSelectInput (XW[id].display, XW[id].window, ExposureMask | KeyPressMask | ButtonPressMask | PointerMotionMask);
 
   _giza_init_band (mode);
+  _giza_expand_clipping_xw();
 
  while(1) {
 

--- a/src/giza-driver-xw.c
+++ b/src/giza-driver-xw.c
@@ -472,7 +472,7 @@ _giza_xevent_loop (int mode, int moveCurs, int nanc, const int *anchorx, const i
            double xpt = (double) event.xmotion.x;
            double ypt = (double) event.xmotion.y;
            cairo_device_to_user (Dev[id].context, &xpt, &ypt);
-           Dev[id].motion_callback(&xpt, &ypt);
+           Dev[id].motion_callback(&xpt, &ypt, &mode);
         }
 
         _giza_refresh_band (mode, nanc, anchorx, anchory, event.xmotion.x, event.xmotion.y);

--- a/src/giza-driver-xw.c
+++ b/src/giza-driver-xw.c
@@ -426,7 +426,7 @@ _giza_xevent_loop (int mode, int moveCurs, int nanc, const int *anchorx, const i
     case ButtonPress:
       {
         *x = event.xbutton.x ;/*- GIZA_XW_MARGIN; */
-	*y = event.xbutton.y ;/*- GIZA_XW_MARGIN; */
+        *y = event.xbutton.y ;/*- GIZA_XW_MARGIN; */
         switch(event.xbutton.button) {
         case Button1:
            if (event.xbutton.state==1) {
@@ -459,13 +459,21 @@ _giza_xevent_loop (int mode, int moveCurs, int nanc, const int *anchorx, const i
         }
         _giza_destroy_band (mode);
         _giza_flush_xw_event_queue(&event);
-	return;
+        return;
       }
     case MotionNotify:
       {
         /* discard all except the last pointer motion event */
         while(XCheckWindowEvent(XW[id].display, XW[id].window,
                               (long)(PointerMotionMask), &event) == True);
+
+        /* if a callback function is set to do things while the cursor is moving, call it */
+        if (Dev[id].motion_callback != NULL) {
+           double xpt = (double) event.xmotion.x;
+           double ypt = (double) event.xmotion.y;
+           cairo_device_to_user (Dev[id].context, &xpt, &ypt);
+           Dev[id].motion_callback(&xpt, &ypt);
+        }
 
         _giza_refresh_band (mode, nanc, anchorx, anchory, event.xmotion.x, event.xmotion.y);
         _giza_flush_xw_event_queue(&event);

--- a/src/giza-driver-xw.c
+++ b/src/giza-driver-xw.c
@@ -419,6 +419,7 @@ _giza_xevent_loop (int mode, int moveCurs, int nanc, const int *anchorx, const i
 
           _giza_destroy_band (mode);
           _giza_flush_xw_event_queue(&event);
+          _giza_reset_clipping_xw();
 	  return;
 	};
 
@@ -460,6 +461,7 @@ _giza_xevent_loop (int mode, int moveCurs, int nanc, const int *anchorx, const i
         }
         _giza_destroy_band (mode);
         _giza_flush_xw_event_queue(&event);
+        _giza_reset_clipping_xw();
         return;
       }
     case MotionNotify:
@@ -538,6 +540,18 @@ _giza_expand_clipping_xw (void)
   cairo_reset_clip (Dev[id].context);
   cairo_rectangle (Dev[id].context, 0, 0, XW[id].width, XW[id].height);
   cairo_clip (Dev[id].context);
+}
+
+/**
+ * Restores clipping of the plotting surface
+ */
+void
+_giza_reset_clipping_xw (void)
+{
+  /* Restore clipping */
+  giza_set_viewport (Dev[id].VP.xmin, Dev[id].VP.xmax, Dev[id].VP.ymin, Dev[id].VP.ymax);
+  _giza_set_trans (GIZA_TRANS_WORLD);
+
 }
 
 /**

--- a/src/giza-driver-xw.c
+++ b/src/giza-driver-xw.c
@@ -474,6 +474,9 @@ _giza_xevent_loop (int mode, int moveCurs, int nanc, const int *anchorx, const i
         if (Dev[id].motion_callback != NULL) {
            double xpt = (double) event.xmotion.x;
            double ypt = (double) event.xmotion.y;
+           /* make sure the transform is to world coords, because arbitrary drawing
+              can happen in the callback routine, which may change the transform */
+           _giza_set_trans (GIZA_TRANS_WORLD);
            cairo_device_to_user (Dev[id].context, &xpt, &ypt);
            Dev[id].motion_callback(&xpt, &ypt, &mode);
         }

--- a/src/giza-drivers.c
+++ b/src/giza-drivers.c
@@ -257,6 +257,7 @@ giza_open_device_size (const char *newDeviceName, const char *newPrefix, double 
    * These routines check for Dev[id].deviceOpen so we must set that */
   Dev[id].deviceOpen = 1;
   Dev[id].defaultBackgroundAlpha = 1.;
+  Dev[id].motion_callback = NULL;
 
   giza_set_text_background (-1);
   giza_start_prompting ();
@@ -722,6 +723,32 @@ giza_query_device (const char *querytype, char *returnval, int* rlen)
     }
   returnval[max_chars] = '\0'; /* make sure string is null-terminated */
   return ierr;
+}
+
+/**
+ * Device: giza_set_motion_callback
+ *
+ * Synopsis: set a callback function to be called
+ *           during cursor movement (e.g. to print things)
+ *           Function should be of the form
+ *           void func(double *x, double *y)
+ *
+ * Input:
+ *  -func  :- The subroutine to be called
+ *
+ */
+int
+giza_set_motion_callback (void (*func)(double *x, double *y))
+{
+  if (!_giza_check_device_ready ("giza_set_motion_callback"))
+    return 1;
+
+  /*if (Dev[id].motion_callback != NULL) printf("WARNING: motion callback already set\n");*/
+
+  /* assign the motion pointer callback */
+  Dev[id].motion_callback = func;
+
+  return 0;
 }
 
 /**

--- a/src/giza-drivers.c
+++ b/src/giza-drivers.c
@@ -738,7 +738,7 @@ giza_query_device (const char *querytype, char *returnval, int* rlen)
  *
  */
 int
-giza_set_motion_callback (void (*func)(double *x, double *y))
+giza_set_motion_callback (void (*func)(double *x, double *y, int *mode))
 {
   if (!_giza_check_device_ready ("giza_set_motion_callback"))
     return 1;

--- a/src/giza-drivers.c
+++ b/src/giza-drivers.c
@@ -743,12 +743,36 @@ giza_set_motion_callback (void (*func)(double *x, double *y, int *mode))
   if (!_giza_check_device_ready ("giza_set_motion_callback"))
     return 1;
 
-  /*if (Dev[id].motion_callback != NULL) printf("WARNING: motion callback already set\n");*/
-
   /* assign the motion pointer callback */
   Dev[id].motion_callback = func;
 
   return 0;
+}
+
+/**
+ * Device: giza_end_motion_callback
+ *
+ * Synopsis: Free the motion callback pointer
+ *
+ * See: giza_end_motion_callback
+ *
+ */
+int
+giza_end_motion_callback (void)
+{
+  if (!_giza_check_device_ready ("giza_end_motion_callback"))
+    return 1;
+
+  if (Dev[id].motion_callback != NULL)
+     {
+       Dev[id].motion_callback = NULL;
+       return 0;
+     }
+  else
+     {
+       return 1; /* return error if already null */
+     }
+
 }
 
 /**

--- a/src/giza-fortran.F90
+++ b/src/giza-fortran.F90
@@ -694,9 +694,10 @@ private
       import
       integer(kind=c_int) :: giza_set_motion_callback
       abstract interface
-       subroutine func(x,y) bind(c)
+       subroutine func(x,y,mode) bind(c)
          import
          real(c_double), intent(in) :: x,y
+         integer(c_int), intent(in) :: mode
        end subroutine
       end interface
     end function giza_set_motion_callback

--- a/src/giza-fortran.F90
+++ b/src/giza-fortran.F90
@@ -1956,9 +1956,9 @@ contains
     character(kind=c_char), dimension(len(string)+1) :: array
     integer :: i, ilen
 
-    ilen = len_trim(string) ! use the trimmed string length
-    do i=1, ilen
-      array(i)=string(i:i)
+    ilen = len(string) ! use the trimmed string length
+    do i=1,ilen
+       array(i)=string(i:i)
     end do
     array(ilen+1)=achar(0)
 

--- a/src/giza-fortran.F90
+++ b/src/giza-fortran.F90
@@ -73,6 +73,7 @@ module giza
       giza_close_device, &
       giza_close, &
       giza_get_key_press, &
+      giza_set_motion_callback, &
       giza_device_has_cursor, &
       giza_draw, &
       giza_draw_background, &
@@ -219,7 +220,7 @@ private
       import
       real(kind=c_double),intent(in),value :: x1,y1,x2,y2
     end subroutine giza_arrow
-    
+
     subroutine giza_arrow_float(x1,y1,x2,y2) bind(C)
       import
       real(kind=c_float),intent(in),value :: x1,y1,x2,y2
@@ -277,21 +278,21 @@ private
  interface giza_annotate
     module procedure giza_intern_annotate_f2c
  end interface
- 
+
  interface giza_annotate_c
     subroutine giza_annotate_c (side,displacement,coord,justification,text) bind(C,name="giza_annotate")
       import
       character(kind=c_char),dimension(*),intent(in) :: side,text
       real(kind=c_double),intent(in),value    ::displacement,coord,justification
     end subroutine giza_annotate_c
-    
+
     subroutine giza_annotate_float_c (side,displacement,coord,justification,text) bind(C,name="giza_annotate_float")
       import
       character(kind=c_char),dimension(*),intent(in) :: side,text
       real(kind=c_float),intent(in),value     ::displacement,coord,justification
     end subroutine giza_annotate_float_c
  end interface
- 
+
  interface giza_box
     module procedure giza_intern_box_f2c
  end interface
@@ -299,7 +300,7 @@ private
  interface giza_box_time
     module procedure giza_intern_box_time_f2c
  end interface
- 
+
  interface giza_box_c
     subroutine giza_box_float_c(xopt,xtick,nxsub,yopt,ytick,nysub) bind(C,name="giza_box_float")
       import
@@ -307,7 +308,7 @@ private
       real(kind=c_float), value, intent(in)    :: xtick,ytick
       integer(kind=c_int), value, intent(in)   :: nxsub,nysub
     end subroutine giza_box_float_c
-    
+
     subroutine giza_box_c(xopt,xtick,nxsub,yopt,ytick,nysub) bind(C,name="giza_box")
       import
       character(kind=c_char),dimension(*), intent(in) :: xopt,yopt
@@ -323,7 +324,7 @@ private
       real(kind=c_float), value, intent(in)    :: xtick,ytick
       integer(kind=c_int), value, intent(in)   :: nxsub,nysub
     end subroutine giza_box_time_float_c
-    
+
     subroutine giza_box_time_c(xopt,xtick,nxsub,yopt,ytick,nysub) bind(C,name="giza_box_time")
       import
       character(kind=c_char),dimension(*), intent(in) :: xopt,yopt
@@ -359,24 +360,24 @@ private
     end subroutine giza_circle_float
  end interface
 
- interface giza_set_character_height 
+ interface giza_set_character_height
     subroutine giza_set_character_height(ch) bind(C)
       import
       real(kind=c_double),intent(in),value :: ch
     end subroutine giza_set_character_height
-    
+
     subroutine giza_set_character_height_float(ch) bind(C)
       import
       real(kind=c_float),intent(in),value :: ch
     end subroutine giza_set_character_height_float
  end interface
- 
+
  interface giza_get_character_height
     subroutine giza_get_character_height(ch) bind(C)
       import
       real(kind=c_double),intent(out) :: ch
     end subroutine giza_get_character_height
-    
+
     subroutine giza_get_character_height_float(ch) bind(C)
       import
       real(kind=c_float),intent(out) :: ch
@@ -389,7 +390,7 @@ private
       integer(kind=c_int),intent(in),value :: units
       real(kind=c_double),intent(out)      :: xch,ych
     end subroutine giza_get_character_size
-    
+
     subroutine giza_get_character_size_float(units,xch,ych) bind(C)
       import
       integer(kind=c_int),intent(in),value :: units
@@ -470,7 +471,7 @@ private
       integer(kind=c_int), value, intent(in)    :: ci
       real(kind=c_float), value, intent(in)     :: red,green,blue
     end subroutine giza_set_colour_representation_float
-    
+
     subroutine giza_set_colour_representation(ci,red,green,blue) bind(C)
       import
       integer(kind=c_int), value, intent(in) :: ci
@@ -482,7 +483,7 @@ private
       integer(kind=c_int), value, intent(in)    :: ci
       real(kind=c_float), value, intent(in)     :: red,green,blue,alpha
     end subroutine giza_set_colour_representation_alpha_float
-    
+
     subroutine giza_set_colour_representation_alpha(ci,red,green,blue,alpha) bind(C)
       import
       integer(kind=c_int), value, intent(in) :: ci
@@ -496,7 +497,7 @@ private
       integer(kind=c_int),intent(in),value       :: ci
       real(kind=c_double),intent(out) :: red,green,blue
     end subroutine giza_get_colour_representation
-   
+
     subroutine giza_get_colour_representation_float(ci,red,green,blue) bind(C)
       import
       integer(kind=c_int),intent(in),value       :: ci
@@ -508,7 +509,7 @@ private
       integer(kind=c_int),intent(in),value       :: ci
       real(kind=c_double),intent(out) :: red,green,blue,alpha
     end subroutine giza_get_colour_representation_alpha
-   
+
     subroutine giza_get_colour_representation_alpha_float(ci,red,green,blue,alpha) bind(C)
       import
       integer(kind=c_int),intent(in),value       :: ci
@@ -537,7 +538,7 @@ private
       real(kind=c_double),intent(in),dimension(n) :: controlPoints,red,green,blue
       real(kind=c_double),intent(in),value        :: cont,bright
     end subroutine giza_set_colour_table
-    
+
     subroutine giza_set_colour_table_float(controlPoints,red,green,blue,n,cont,bright) bind(C)
       import
       integer(kind=c_int),intent(in),value       :: n
@@ -554,7 +555,7 @@ private
       real(kind=c_double),intent(in) :: cont(ncont)
       real(kind=c_double),intent(in) :: affine(6)
     end subroutine giza_contour
-    
+
     subroutine giza_contour_float(sizex,sizey,data,i1,i2,j1,j2,ncont,cont,affine) bind(C)
       import
       integer(kind=c_int),intent(in),value :: sizex,sizey,i1,i2,j1,j2,ncont
@@ -569,7 +570,7 @@ private
       import
       real(kind=c_double),intent(out) :: xpt,ypt
     end subroutine giza_get_current_point
-    
+
     subroutine giza_get_current_point_float(xpt,ypt) bind(C)
       import
       real(kind=c_float),intent(out) :: xpt,ypt
@@ -628,7 +629,7 @@ private
       integer(kind=c_int),intent(in),value    :: units
     end function giza_open_device_size_float_c
  end interface
- 
+
 ! device_has_cursor is logical in Fortran but int in c
 ! (cannot do a generic interface for int/logical), can call c version directly with _int version
  interface giza_device_has_cursor
@@ -686,6 +687,19 @@ private
       real(kind=c_float),intent(out)     :: x,y
       character(kind=c_char),intent(out) :: ch
     end function giza_get_key_press_float
+ end interface
+
+ interface giza_set_motion_callback
+    function giza_set_motion_callback(func) bind(C)
+      import
+      integer(kind=c_int) :: giza_set_motion_callback
+      abstract interface
+       subroutine func(x,y) bind(c)
+         import
+         real(c_double), intent(in) :: x,y
+       end subroutine
+      end interface
+    end function giza_set_motion_callback
  end interface
 
  interface giza_draw
@@ -773,7 +787,7 @@ private
       integer(kind=c_int),intent(in),value :: fs
     end subroutine giza_set_fill
  end interface
- 
+
  interface giza_get_fill
     subroutine giza_get_fill(fs) bind(C)
       import
@@ -887,7 +901,7 @@ private
       real(kind=c_double),intent(out) :: x1,x2,y1,y2
     end subroutine giza_get_surface_size
  end interface
- 
+
  interface giza_set_hatching_style
     subroutine giza_set_hatching_style(angle,spacing,phase) bind(C)
       import
@@ -945,7 +959,7 @@ private
  interface giza_label
     module procedure giza_intern_label_f2c
  end interface
- 
+
  interface giza_label_c
     subroutine giza_label_c (labelx,labely,title) bind(C,name="giza_label")
       import
@@ -966,32 +980,32 @@ private
       real(kind=c_double),intent(in),dimension(n) :: xpts,ypts
     end subroutine giza_line
  end interface
- 
+
  interface giza_set_line_width
     subroutine giza_set_line_width(lw) bind(C)
       import
       real(kind=c_double),intent(in), value :: lw
     end subroutine giza_set_line_width
-    
+
     subroutine giza_set_line_width_float(lw) bind(C)
       import
       real(kind=c_float),intent(in), value :: lw
     end subroutine giza_set_line_width_float
-    
+
     module procedure giza_intern_set_line_width_int
  end interface
- 
+
  interface giza_get_line_width
     subroutine giza_get_line_width(lw) bind(C)
       import
       real(kind=c_double),intent(out) :: lw
     end subroutine giza_get_line_width
-    
+
     subroutine giza_get_line_width_float(lw) bind(C)
       import
       real(kind=c_float),intent(out) :: lw
     end subroutine giza_get_line_width_float
-    
+
     module procedure giza_intern_get_line_width_int
  end interface
 
@@ -1022,7 +1036,7 @@ private
       integer(c_int),intent(out) :: ls
     end subroutine giza_get_line_style
  end interface
- 
+
  interface giza_mark_line
     subroutine giza_mark_line(maxpts,npts,xpts,ypts) bind(C)
       import
@@ -1031,7 +1045,7 @@ private
       real(kind=c_double), dimension(*), intent(inout) :: xpts
       real(kind=c_double), dimension(*), intent(inout) :: ypts
     end subroutine giza_mark_line
-    
+
     subroutine giza_mark_line_float(maxpts,npts,xpts,ypts) bind(C)
       import
       integer(kind=c_int),intent(in),value :: maxpts
@@ -1048,7 +1062,7 @@ private
       real(kind=c_double), dimension(*), intent(inout) :: ypts
       character(kind=c_char),intent(out)   :: ch
     end subroutine giza_mark_line_char
-    
+
     subroutine giza_mark_line_char_float(maxpts,npts,xpts,ypts,ch) bind(C)
       import
       integer(kind=c_int),intent(in),value :: maxpts
@@ -1067,7 +1081,7 @@ private
       real(kind=c_double), dimension(*), intent(inout) :: xpts
       real(kind=c_double), dimension(*), intent(inout) :: ypts
     end subroutine giza_mark_line_ordered
-    
+
     subroutine giza_mark_line_ordered_float(maxpts,npts,xpts,ypts) bind(C)
       import
       integer(kind=c_int),intent(in),value :: maxpts
@@ -1086,7 +1100,7 @@ private
       real(kind=c_double), dimension(*), intent(inout) :: ypts
       integer(kind=c_int),intent(in),value :: symbol
     end subroutine giza_mark_points
-    
+
     subroutine giza_mark_points_float(maxpts,npts,xpts,ypts,symbol) bind(C)
       import
       integer(kind=c_int),intent(in),value :: maxpts
@@ -1106,7 +1120,7 @@ private
       real(kind=c_double), dimension(*), intent(inout) :: ypts
       integer(kind=c_int),intent(in),value :: symbol
     end subroutine giza_mark_points_ordered
-    
+
     subroutine giza_mark_points_ordered_float(maxpts,npts,xpts,ypts,symbol) bind(C)
       import
       integer(kind=c_int),intent(in),value :: maxpts
@@ -1116,7 +1130,7 @@ private
       integer(kind=c_int),intent(in),value :: symbol
     end subroutine giza_mark_points_ordered_float
  end interface
- 
+
  interface giza_move
     subroutine giza_move(x,y) bind(C)
       import
@@ -1215,7 +1229,7 @@ private
  end interface
 
  interface giza_text
-    module procedure giza_intern_text_f2c    
+    module procedure giza_intern_text_f2c
     module procedure giza_intern_text_float_f2c
  end interface
 
@@ -1252,7 +1266,7 @@ private
  end interface giza_open
 
  interface giza_ptext
-    module procedure giza_intern_ptext_f2c    
+    module procedure giza_intern_ptext_f2c
     module procedure giza_intern_ptext_float_f2c
  end interface
 
@@ -1271,7 +1285,7 @@ private
  end interface
 
  interface giza_qtext
-    module procedure giza_intern_qtext_f2c   
+    module procedure giza_intern_qtext_f2c
     module procedure giza_intern_qtext_float_f2c
  end interface
 
@@ -1292,7 +1306,7 @@ private
  end interface
 
  interface giza_qtextlen
-    module procedure giza_intern_qtextlen_f2c   
+    module procedure giza_intern_qtextlen_f2c
     module procedure giza_intern_qtextlen_float_f2c
  end interface
 
@@ -1320,7 +1334,7 @@ private
       real(kind=c_double),intent(in),value :: valMin,valMax
       real(kind=c_double),intent(in) :: affine(6)
     end subroutine giza_render
-    
+
     subroutine giza_render_float(sizex,sizey,data,i1,i2,j1,j2,valMin,valMax,extend,affine) bind(C)
       import
       integer(kind=c_int),intent(in),value :: sizex,sizey,i1,i2,j1,j2,extend
@@ -1336,7 +1350,7 @@ private
       real(kind=c_double),intent(in),value :: valMin,valMax
       real(kind=c_double),intent(in) :: affine(6)
     end subroutine giza_render_alpha
-    
+
     subroutine giza_render_alpha_float(sizex,sizey,data,alpha,i1,i2,j1,j2,valMin,valMax,extend,affine) bind(C)
       import
       integer(kind=c_int),intent(in),value :: sizex,sizey,i1,i2,j1,j2,extend
@@ -1354,7 +1368,7 @@ private
       real(kind=c_double),intent(in),value :: valMin,valMax
       real(kind=c_double),intent(in) :: affine(6)
     end subroutine giza_render_transparent
-    
+
     subroutine giza_render_transparent_float(sizex,sizey,data,i1,i2,j1,j2,valMin,valMax,extend,affine) bind(C)
       import
       integer(kind=c_int),intent(in),value :: sizex,sizey,i1,i2,j1,j2,extend
@@ -1372,7 +1386,7 @@ private
       real(kind=c_double),intent(in),value :: valMin,valMax
       real(kind=c_double),intent(in) :: affine(6)
     end subroutine giza_render_gray
-    
+
     subroutine giza_render_gray_float(sizex,sizey,data,i1,i2,j1,j2,valMin,valMax,extend,affine) bind(C)
       import
       integer(kind=c_int),intent(in),value :: sizex,sizey,i1,i2,j1,j2,extend
@@ -1389,7 +1403,7 @@ private
       integer(kind=c_int),intent(in) :: idata(sizex,sizey)
       real(kind=c_double),intent(in),value :: xmin,xmax,ymin,ymax
     end subroutine giza_draw_pixels
-    
+
     subroutine giza_draw_pixels_float(sizex,sizey,idata,i1,i2,j1,j2,xmin,xmax,ymin,ymax,extend) bind(C)
       import
       integer(kind=c_int),intent(in),value :: sizex,sizey,i1,i2,j1,j2,extend
@@ -1440,7 +1454,7 @@ private
       real(kind=c_float) :: giza_round_float
     end function giza_round_float
  end interface giza_round
- 
+
  interface giza_save
     subroutine giza_save() bind(C)
     end subroutine giza_save
@@ -1493,7 +1507,7 @@ private
       integer(kind=c_int), intent(in),value :: nx,ny
     end subroutine giza_subpanel
  end interface
- 
+
  interface giza_set_panel
     subroutine giza_set_panel(ix,iy) bind(C)
       import
@@ -1516,7 +1530,7 @@ private
       real(kind=c_double),intent(in),value :: scale,blank
       real(kind=c_double),intent(in) :: affine(6)
     end subroutine giza_vector
-    
+
     subroutine giza_vector_float(sizex,sizey,horizontal,vertical,i1,i2,j1,j2,scale,position,affine,blank) bind(C)
       import
       integer(kind=c_int),intent(in),value :: sizex,sizey,i1,i2,j1,j2,position
@@ -1550,7 +1564,7 @@ private
       integer(kind=c_int), value, intent(in)  :: units
       real(kind=c_double),        intent(out) :: x1,x2,y1,y2
     end subroutine giza_get_viewport
-    
+
     subroutine giza_get_viewport_float(units,x1,x2,y1,y2) bind(C)
       import
       integer(kind=c_int),value, intent(in)  :: units
@@ -1569,7 +1583,7 @@ private
       real(kind=c_double), value, intent(in) :: xleft,xright,ybot,ytop
     end subroutine giza_set_viewport_inches
  end interface
- 
+
  interface giza_version
     subroutine giza_version(major,minor,micro) bind(C)
      import
@@ -1654,7 +1668,7 @@ contains
 
 !-------------------------------------------------------
 ! these are subroutines whose arguments need conversion
-! before passing to c (mainly strings)       
+! before passing to c (mainly strings)
 !-------------------------------------------------------
 
   subroutine giza_intern_annotate_f2c(side,displacement,coord,justification,text)
@@ -1703,20 +1717,20 @@ contains
     character(len=*), intent(in) :: side,label
     real, intent(in) :: disp,width,valmin,valmax
     real(kind=c_double) :: disp_c,width_c,valmin_c,valmax_c
-    
+
     disp_c = disp
     width_c = width
     valmin_c = valmin
     valmax_c = valmax
-    
+
     call giza_colour_bar_c(cstring(side),disp_c,width_c,valmin_c,valmax_c,cstring(label))
-    
+
   end subroutine giza_intern_colour_bar_f2c
 
   integer function  giza_intern_open_device(dev,prefix)
     implicit none
     character(len=*),intent(in) :: dev,prefix
-    
+
     giza_intern_open_device = giza_open_device_c(cstring(dev),cstring(prefix))
   end function giza_intern_open_device
 
@@ -1728,15 +1742,15 @@ contains
     integer, intent(in), optional :: units
     integer, intent(out), optional :: error
     integer :: giza_open
-    
+
     character(len=40) :: fdev
     if (present(dev)) then
        fdev = dev
     else
        fdev = '?'
     endif
-    
-    if (present(units) .and. present(width) .and. present(height)) then    
+
+    if (present(units) .and. present(width) .and. present(height)) then
        if (present(prefix)) then
           giza_open = giza_open_device_size_c(cstring(fdev),cstring(prefix),width,height,units)
        else
@@ -1752,9 +1766,9 @@ contains
     if (present(error)) then
        error = giza_open
     endif
-  
+
   end subroutine giza_open_sub
-  
+
   subroutine giza_close
      call giza_close_device()
   end subroutine giza_close
@@ -1765,12 +1779,12 @@ contains
     character(len=*),intent(in) :: dev,prefix
     real,intent(in)             :: width,height
     integer, intent(in)         :: units
-    
+
     giza_intern_open_device_size = giza_open_device_size_c(cstring(dev),cstring(prefix),width,height,units)
-  
+
   end function giza_intern_open_device_size
 
-  ! So cursor functionality can be queried as logical 
+  ! So cursor functionality can be queried as logical
   logical function giza_intern_device_has_cursor()
     implicit none
 
@@ -1781,7 +1795,7 @@ contains
   subroutine giza_intern_label_f2c(labelx,labely,title)
     implicit none
     character(len=*),intent(in) :: labelx,labely,title
-    
+
     call giza_label_c(cstring(labelx),cstring(labely),cstring(title))
 
   end subroutine giza_intern_label_f2c
@@ -1790,7 +1804,7 @@ contains
     implicit none
     integer(kind=c_int),value,intent(in) :: lw
     real(kind=c_double) :: reallw
-    
+
     !--cairo line widths are best as .5, 1.5 etc
     reallw = dble(lw) + 0.5d0
     call giza_set_line_width(reallw)
@@ -1817,7 +1831,7 @@ contains
     implicit none
     real(kind=c_float),intent(in) :: x,y
     character(len=*),intent(in)    :: text
-    
+
     call giza_text_float_c(x,y,cstring(text))
   end subroutine giza_intern_text_float_f2c
 
@@ -1833,7 +1847,7 @@ contains
     implicit none
     real(kind=c_float),intent(in) :: x,y,angle,just
     character(len=*),intent(in)    :: text
-    
+
     call giza_ptext_float_c(x,y,angle,just,cstring(text))
   end subroutine giza_intern_ptext_float_f2c
 
@@ -1851,7 +1865,7 @@ contains
     real(kind=c_float),intent(in) :: x,y,angle,just
     real(kind=c_float),intent(out):: xbox(4),ybox(4)
     character(len=*),intent(in)   :: text
-    
+
     call giza_qtext_float_c(x,y,angle,just,cstring(text),xbox,ybox)
   end subroutine giza_intern_qtext_float_f2c
 
@@ -1876,7 +1890,7 @@ contains
   subroutine giza_intern_set_font_f2c(font)
     implicit none
     character(len=*),intent(in) :: font
-  
+
     call giza_set_font_c(cstring(font))
 
   end subroutine giza_intern_set_font_f2c
@@ -1884,7 +1898,7 @@ contains
   subroutine giza_intern_set_font_bold_f2c(font)
     implicit none
     character(len=*),intent(in) :: font
-  
+
     call giza_set_font_bold_c(cstring(font))
 
   end subroutine giza_intern_set_font_bold_f2c
@@ -1892,7 +1906,7 @@ contains
   subroutine giza_intern_set_font_italic_f2c(font)
     implicit none
     character(len=*),intent(in) :: font
-  
+
     call giza_set_font_italic_c(cstring(font))
 
   end subroutine giza_intern_set_font_italic_f2c
@@ -1900,7 +1914,7 @@ contains
   subroutine giza_intern_set_font_bold_italic_f2c(font)
     implicit none
     character(len=*),intent(in) :: font
-  
+
     call giza_set_font_bold_italic_c(cstring(font))
 
   end subroutine giza_intern_set_font_bold_italic_f2c
@@ -1911,7 +1925,7 @@ contains
     character(len=*),  intent(out) :: string
     character(kind=c_char), dimension(len(string)+1) :: stringc
     integer(kind=c_int) :: cstring_length
-    cstring_length = len(string)+1 
+    cstring_length = len(string)+1
     call giza_format_number_c(mantissa,power,iform,stringc,cstring_length)
     string = fstring(stringc)
 
@@ -1924,10 +1938,10 @@ contains
     integer(kind=c_int) :: rval
     integer(kind=c_int) :: ierr
     character(kind=c_char), dimension(len(string)+1) :: stringc
-    rval = len(string)+1 
+    rval = len(string)+1
     ierr = giza_query_device_c(cstring(qtype),stringc,rval)
     string = fstring(stringc)
-  
+
   end subroutine giza_query_device_f2c
 
   !---------------------------------------------------------------------------
@@ -2002,7 +2016,7 @@ subroutine giza_plot(y,x,img,dev,prefix,width,height,units,&
  character(len=20) :: devi
  character(len=40) :: xlabeli,ylabeli,titlei
  real(kind=c_double), dimension(:), allocatable :: arrtmp
- 
+
  real(kind=c_double)  :: lw_c, ch_c
  integer(kind=c_int)  :: n, nx_c, ny_c
  integer(kind=c_int)  :: symbol_c, iextend
@@ -2028,7 +2042,7 @@ subroutine giza_plot(y,x,img,dev,prefix,width,height,units,&
     endif
  else
     if (present(prefix)) then
-       call giza_open(dev=devi,prefix=prefix)    
+       call giza_open(dev=devi,prefix=prefix)
     else
        call giza_open(dev=devi)
     endif
@@ -2046,7 +2060,7 @@ subroutine giza_plot(y,x,img,dev,prefix,width,height,units,&
        xmini = 0.
     endif
  endif
- if (present(xmax)) then    
+ if (present(xmax)) then
     xmaxi = xmax
  else
     if (present(x)) then
@@ -2142,12 +2156,12 @@ subroutine giza_plot(y,x,img,dev,prefix,width,height,units,&
  if (present(ci)) then
     call giza_set_colour_index(ci)
  endif
- 
+
  if (present(x) .and. present(y)) then
     n = min(size(x),size(y))
     if (present(symbol)) then
        symbol_c = symbol
-       call giza_points(n,real(x,kind=c_double),real(y,kind=c_double),symbol_c)    
+       call giza_points(n,real(x,kind=c_double),real(y,kind=c_double),symbol_c)
     else
        call giza_line(n,real(x,kind=c_double),real(y,kind=c_double))
     endif
@@ -2178,7 +2192,7 @@ subroutine giza_plot(y,x,img,dev,prefix,width,height,units,&
     endif
     deallocate(arrtmp)
  endif
- 
+
  if (present(img)) then
     nx = size(img(:,1))
     ny = size(img(1,:))
@@ -2208,9 +2222,9 @@ subroutine giza_plot(y,x,img,dev,prefix,width,height,units,&
     call giza_render(nx_c,ny_c,real(img,kind=c_double),int(1,kind=c_int),&
                      nx_c,int(1,kind=c_int),ny_c,valmin,valmax,iextend,affinei)
  endif
- 
+
  call giza_close()
- 
+
 end subroutine giza_plot
 
 end module giza

--- a/src/giza-fortran.F90
+++ b/src/giza-fortran.F90
@@ -75,6 +75,7 @@ module giza
       giza_close, &
       giza_get_key_press, &
       giza_set_motion_callback, &
+      giza_end_motion_callback, &
       giza_device_has_cursor, &
       giza_draw, &
       giza_draw_background, &
@@ -729,6 +730,13 @@ private
     end function giza_set_motion_callback
  end interface
 
+ interface giza_end_motion_callback
+    function giza_end_motion_callback() bind(C)
+      import
+      integer(kind=c_int) :: giza_end_motion_callback
+    end function giza_end_motion_callback
+ end interface
+
  interface giza_draw
     subroutine giza_draw(x,y) bind(C)
       import
@@ -743,7 +751,7 @@ private
 
  interface giza_draw_background
     subroutine giza_draw_background() bind(C)
-    end subroutine
+    end subroutine giza_draw_background
  end interface
 
  interface giza_set_environment

--- a/src/giza-fortran.F90
+++ b/src/giza-fortran.F90
@@ -37,6 +37,7 @@ module giza
       giza_set_arrow_style, &
       giza_get_arrow_style, &
       giza_annotate, &
+      giza_axis, &
       giza_band, &
       giza_box, &
       giza_box_time, &
@@ -254,6 +255,31 @@ private
       real(kind=c_float) ,intent(out) :: angle,cutback
     end subroutine giza_get_arrow_style_float
  end interface
+
+ interface giza_axis
+    module procedure giza_intern_axis_f2c
+ end interface
+
+ interface giza_axis_c
+    subroutine giza_axis_float_c(opt,x1,y1,x2,y2,v1,v2,&
+               tick,nsub,dmajl,dmajr,fmin,disp,angle) bind(C,name="giza_axis_float")
+      import
+      character(kind=c_char),dimension(*), intent(in) :: opt
+      real(kind=c_float), value, intent(in)  :: x1,y1,x2,y2,v1,v2
+      real(kind=c_float), value, intent(in)  :: tick,dmajl,dmajr,fmin,disp,angle
+      integer(kind=c_int), value, intent(in) :: nsub
+    end subroutine giza_axis_float_c
+
+    subroutine giza_axis_c(opt,x1,y1,x2,y2,v1,v2,&
+               tick,nsub,dmajl,dmajr,fmin,disp,angle) bind(C,name="giza_axis")
+      import
+      character(kind=c_char),dimension(*), intent(in) :: opt
+      real(kind=c_double), value, intent(in)   :: x1,y1,x2,y2,v1,v2
+      real(kind=c_double), value, intent(in)   :: tick,dmajl,dmajr,fmin,disp,angle
+      integer(kind=c_int), value, intent(in)   :: nsub
+    end subroutine giza_axis_c
+ end interface
+
 
  interface giza_band
     function giza_band(mode,moveCurs,xanc,yanc,x,y,ch) bind(C)
@@ -1684,6 +1710,27 @@ contains
 
     call giza_annotate_c(cstring(side),displacement_c,coord_c,justification_c,cstring(text))
   end subroutine giza_intern_annotate_f2c
+
+  subroutine giza_intern_axis_f2c(opt,x1,y1,x2,y2,v1,v2,&
+             tick,nsub,dmajl,dmajr,fmin,disp,angle)
+    implicit none
+    character(len=*),intent(in) :: opt
+    real, intent(in)  :: x1,y1,x2,y2,v1,v2
+    real, intent(in)  :: tick,dmajl,dmajr,fmin,disp,angle
+    integer,intent(in)  :: nsub
+    real(kind=c_double) :: x1_c,y1_c,x2_c,y2_c,v1_c,v2_c
+    real(kind=c_double) :: tick_c,dmajl_c,dmajr_c,fmin_c,disp_c,angle_c
+    integer(kind=c_int) :: nsub_c
+
+    x1_c = x1; y1_c = y1; x2_c = x2; y2_c = y2; v1_c = v1; v2_c = v2
+    tick_c = tick; dmajl_c = dmajl; dmajr_c = dmajr; fmin_c = fmin
+    disp_c = disp; angle_c = angle
+    nsub_c = nsub
+
+    call giza_axis_c(cstring(opt),x1_c,y1_c,x2_c,y2_c,v1_c,v2_c,&
+                     tick_c,nsub_c,dmajl_c,dmajr_c,fmin_c,disp_c,angle_c)
+
+  end subroutine giza_intern_axis_f2c
 
   subroutine giza_intern_box_f2c(xopt,xtick,nxsub,yopt,ytick,nysub)
     implicit none

--- a/src/giza-pgplot.f90
+++ b/src/giza-pgplot.f90
@@ -121,14 +121,17 @@ end subroutine PGASK
 
 !------------------------------------------------------------------------
 ! Module: PGAXIS -- draw an axis
-! Status: NOT IMPLEMENTED
+! Status: IMPLEMENTED
 !------------------------------------------------------------------------
 subroutine PGAXIS (OPT, X1, Y1, X2, Y2, V1, V2, STEP, NSUB, DMAJL, DMAJR, FMIN, DISP, ORIENT)
+ use giza, only:giza_axis
  implicit none
  character*(*), intent(in) :: OPT
  real, intent(in) :: X1, Y1, X2, Y2, V1, V2, STEP, DMAJL, DMAJR, FMIN, DISP
  real, intent(in) :: ORIENT
  integer, intent(in) :: NSUB
+
+ call giza_axis(OPT, X1, Y1, X2, Y2, V1, V2, STEP, NSUB, DMAJL, DMAJR, FMIN, DISP, ORIENT)
 
 end subroutine PGAXIS
 

--- a/src/giza-private.h
+++ b/src/giza-private.h
@@ -77,6 +77,9 @@ typedef struct
   cairo_font_face_t*  font;
 } giza_font_t;
 
+/* type definition for the motion callback function */
+typedef void (*giza_callback_t)(double *x, double *y);
+
 /* Store variables relating to the current device */
 typedef struct
 {
@@ -125,6 +128,7 @@ typedef struct
   cairo_font_extents_t fontExtents;
   double fontAngle;
   int number_format;
+  giza_callback_t motion_callback;
 } giza_device_t;
 
 extern giza_device_t Dev[GIZA_MAX_DEVICES];

--- a/src/giza-private.h
+++ b/src/giza-private.h
@@ -78,7 +78,7 @@ typedef struct
 } giza_font_t;
 
 /* type definition for the motion callback function */
-typedef void (*giza_callback_t)(double *x, double *y);
+typedef void (*giza_callback_t)(double *x, double *y, int *mode);
 
 /* Store variables relating to the current device */
 typedef struct

--- a/src/giza-ptext.c
+++ b/src/giza-ptext.c
@@ -56,7 +56,7 @@ giza_ptext (double x, double y, double angle, double just, const char *text)
   giza_get_character_height (&ch);
 
   cairo_save (Dev[id].context);
-  
+
   /* save the font (can be changed by \rm \fn \fc during text write) */
   int len = GIZA_FONT_LEN;
   char giza_font[len];
@@ -73,11 +73,14 @@ giza_ptext (double x, double y, double angle, double just, const char *text)
   /* Draw the bounding box */
   if (Dev[id].text_background >= 0)
   {
-    int oldCi;
+    int oldCi,oldfill;
     giza_get_colour_index (&oldCi);
     giza_set_colour_index (Dev[id].text_background);
+    giza_get_fill (&oldfill);
+    giza_set_fill(GIZA_FILL_SOLID);
     giza_polygon (4, xbox, ybox);
     giza_set_colour_index (oldCi);
+    giza_set_fill (oldfill);
   }
 
   /* change the current trans to world coords */

--- a/src/giza-render.c
+++ b/src/giza-render.c
@@ -38,7 +38,7 @@
  * Input:
  *  -sizex         :- The dimensions of data in the x-direction
  *  -sizey         :- The dimensions of data in the y-direction
- *  -data          :- The data to be render
+ *  -data          :- The data to be rendered
  *  -i1            :- The inclusive range of data to render in the x dimension.
  *  -i2            :- The inclusive range of data to render in the x dimension.
  *  -j1            :- The inclusive range of data to render in the y direction
@@ -60,7 +60,7 @@
  */
 void
 giza_render (int sizex, int sizey, const double* data, int i1, int i2,
-	    int j1, int j2, double valMin, double valMax, int extend, const double *affine)
+             int j1, int j2, double valMin, double valMax, int extend, const double *affine)
 {
    _giza_render (sizex, sizey, data,i1,i2,j1,j2,valMin,valMax,affine,0,extend,data);
 }
@@ -86,7 +86,7 @@ giza_render_transparent (int sizex, int sizey, const double* data, int i1, int i
  */
 void
 giza_render_alpha (int sizex, int sizey, const double* data, const double* alpha, int i1, int i2,
-	    int j1, int j2, double valMin, double valMax, int extend, const double *affine)
+                   int j1, int j2, double valMin, double valMax, int extend, const double *affine)
 {
    _giza_render (sizex, sizey, data,i1,i2,j1,j2,valMin,valMax,affine,2,extend,alpha);
 }
@@ -97,8 +97,8 @@ giza_render_alpha (int sizex, int sizey, const double* data, const double* alpha
  */
 void
 _giza_render (int sizex, int sizey, const double* data, int i1, int i2,
-	    int j1, int j2, double valMin, double valMax, const double *affine, 
-            int transparent, int extend, const double* datalpha)
+	           int j1, int j2, double valMin, double valMax, const double *affine,
+              int transparent, int extend, const double* datalpha)
 {
   if (!_giza_check_device_ready ("giza_render"))
     return;
@@ -507,7 +507,7 @@ giza_draw_pixels (int sizex, int sizey, const int* idata, int i1, int i2,
   cairo_surface_t *pixmap;
   cairo_matrix_t mat;
   int stride, pixnum, width = i2 - i1 + 1, height = j2 - j1 + 1;
-  
+
   cairo_extend_t cairoextendtype;
   _giza_get_extend(extend,&cairoextendtype);
 

--- a/src/giza-stroke-private.h
+++ b/src/giza-stroke-private.h
@@ -1,7 +1,7 @@
 /* giza - a scientific plotting library built on cairo
  *
  * Copyright (c) 2010      James Wetter and Daniel Price
- * Copyright (c) 2010-2012 Daniel Price
+ * Copyright (c) 2010-2022 Daniel Price
  *
  * This library is free software; and you are welcome to redistribute
  * it under the terms of the GNU General Public License
@@ -23,3 +23,5 @@
  */
 
 void _giza_stroke (void);
+void _giza_tick_intervals (double xmin, double xmax, double xinterval,
+				               int *i1, int *i2);

--- a/src/giza-window.c
+++ b/src/giza-window.c
@@ -72,7 +72,7 @@ giza_set_window (double x1, double x2, double y1, double y2)
   /* Scaling */
   double dxWin = (Win.xmax - Win.xmin);
   double dyWin = (Win.ymax - Win.ymin);
-  
+
   double x0,y0,xfac,yfac;
   if (Dev[id].ix > 0 && Dev[id].iy > 0) { /* sanity check */
      x0 = (Dev[id].ix - 1)*Dev[id].panelwidth/Dev[id].width;

--- a/src/giza.h
+++ b/src/giza.h
@@ -152,7 +152,7 @@ int giza_query_device (const char *querytype, char *returnval, int* rlen);
 int giza_device_has_cursor (void);
 int giza_get_key_press (double *x, double *y, char *ch);
 int giza_get_key_press_float (float *x, float *y, char *ch);
-int giza_set_motion_callback (void (*func)(double *x, double *y));
+int giza_set_motion_callback (void (*func)(double *x, double *y, int *mode));
 
 void giza_draw (double xpt, double ypt);
 void giza_draw_float (float xpt, float ypt);

--- a/src/giza.h
+++ b/src/giza.h
@@ -75,9 +75,9 @@ void giza_get_character_size_float (int units, float *xch, float *ych);
 void giza_set_clipping (int clip);
 void giza_get_clipping (int *clip);
 
-void giza_colour_bar (const char *side, double disp, double width, 
+void giza_colour_bar (const char *side, double disp, double width,
                       double valMin, double valMax, const char *label);
-void giza_colour_bar_float (const char *side, float disp, float width, 
+void giza_colour_bar_float (const char *side, float disp, float width,
                             float valMin, float valMax, const char *label);
 
 void giza_set_colour_index (int ci);
@@ -152,6 +152,7 @@ int giza_query_device (const char *querytype, char *returnval, int* rlen);
 int giza_device_has_cursor (void);
 int giza_get_key_press (double *x, double *y, char *ch);
 int giza_get_key_press_float (float *x, float *y, char *ch);
+int giza_set_motion_callback (void (*func)(double *x, double *y));
 
 void giza_draw (double xpt, double ypt);
 void giza_draw_float (float xpt, float ypt);

--- a/src/giza.h
+++ b/src/giza.h
@@ -161,6 +161,7 @@ int giza_device_has_cursor (void);
 int giza_get_key_press (double *x, double *y, char *ch);
 int giza_get_key_press_float (float *x, float *y, char *ch);
 int giza_set_motion_callback (void (*func)(double *x, double *y, int *mode));
+int giza_end_motion_callback (void);
 
 void giza_draw (double xpt, double ypt);
 void giza_draw_float (float xpt, float ypt);

--- a/src/giza.h
+++ b/src/giza.h
@@ -1,7 +1,7 @@
 /* giza - a scientific plotting library built on cairo
  *
  * Copyright (c) 2010      James Wetter and Daniel Price
- * Copyright (c) 2010-2012 Daniel Price
+ * Copyright (c) 2010-2022 Daniel Price
  *
  * This library is free software; and you are welcome to redistribute
  * it under the terms of the GNU General Public License
@@ -40,6 +40,14 @@ void giza_annotate_float (const char *side, float displacment, float coord,
 			  float justification, const char *string);
 void giza_begin_autolog(void);
 void giza_end_autolog(void);
+
+void giza_axis (const char *opt, double x1, double y1, double x2, double y2,
+          double v1, double v2, double step, int nsub,
+          double dmajl, double dmajr, double fmin, double disp, double angle);
+void giza_axis_float (const char *opt, float x1, float y1, float x2, float y2,
+          float v1, float v2, float step, int nsub,
+          float dmajl, float dmajr, float fmin, float disp, float angle);
+
 int giza_band (int mode, int moveCursm, double xanc, double yanc, double *x,
 	       double *y, char *ch);
 int giza_band_float (int mode, int moveCurs, float xanc, float yanc, float *x,


### PR DESCRIPTION
- adds the ability to specify a callback function func(x,y,mode) that is called every time the cursor moves
- new library functions giza_set_motion_callback and giza_end_motion_callback
- enables more interactivity in applications
- a simple example would be to plot (x,y) coordinates of the cursor in the bottom corner of the screen as the cursor moves


This branch also implements giza_axis, which has replacement functionality for PGAXIS (#12)

Importantly the Fortran API no longer trims text strings before passing them to giza routines. This enables one to send a string of blank characters with an opaque background colour in order to erase previously drawn text