### PR TITLE
Symbol scaling

### DIFF
--- a/src/giza-points.c
+++ b/src/giza-points.c
@@ -434,17 +434,10 @@ _giza_draw_symbol (double xd, double yd, int symbol)
 	case 0:
 	  _giza_rect (xd, yd, 0, 1.5);
 	  break;
-    /* single small point
-       MV: 22 July 2022 According to PGPLOT doc these scale with linewidth, strangely enough
-                        see https://sites.astro.caltech.edu/~tjp/pgplot/subroutines.html#PGPT */
 	case -1:
     case -2:
-          {
-              double lw;
-              giza_get_line_width(&lw);
-              _giza_circle_size( xd, yd, lw, 1);/*_giza_point (xd, yd);*/
-          }
-          break;
+      _giza_point (xd, yd);
+      break;
 	case -3: /* solid polygons */
 	case -4:
 	case -5:
@@ -729,6 +722,7 @@ _giza_polygon (double x, double y, int nsides, int fill, double scale)
 
 /**
  * Draws an n-pointed star at x,y
+ *
  */
 static void
 _giza_star (double x, double y, int npoints, double ratio, int fill, double scale)


### PR DESCRIPTION
Hi @danieljprice !

I've been experimenting with symbol scaling and noticed Giza behaves differently from PGPLOT. I've made an attempt at replicating the PGPLOT behaviour.

According to the docs (https://sites.astro.caltech.edu/~tjp/pgplot/subroutines.html#PGPT) the symbols scale with `character height` and `line width`. I've edited `pgdemo2.f`, `SUBROUTINE PGEX22` to use larger character height (`2.5` in stead of `1.5`) and line width (`8` in stead of `1` or `2` in some cases).

I've attached three screenshots of this `pgdemo2` version w/ different backend libraries :
- PGPLOT output for the larger symbols (notice how linewidth affects them)
- current Giza master branch behaviour
- this pull-request's behaviour

Note: according to those docs symbols `-1` and `-2` should scale with the current line width but the PGDEMO tests showed that PGPLOT 5.2.2 on my Ubuntu doesn't do that at all, so I've left that edit out to be feature compatible. The screenshot was taken _before_ I had tested this behaviour and reverted it in this PR, hence they shop up huge at linewidth=8 ...

Cheers,
Marjolein (fka harro)

![pgdemo2-ex2-hacked-PGPLOT](https://user-images.githubusercontent.com/14309703/180580271-ccf1f6d2-df5b-456f-b75a-23d70fd90d46.png)
![pgdemo2-ex2-hacked-Giza-master](https://user-images.githubusercontent.com/14309703/180580300-54fc27fe-fd05-4778-8a4e-fbaa8998f688.png)
![pgdemo2-ex2-hacked-Giza-symbol-scaling](https://user-images.githubusercontent.com/14309703/180580329-e6ce8c00-c1cc-44f5-8108-f600ca0051cb.png)