### PR TITLE
Support Image Transfer Functions (linear, log, sqrt)

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -23,7 +23,7 @@ libgiza_la_SOURCES = giza-annotate.c giza-arrow-style.c giza-arrow.c giza-axis.c
        giza-render.c giza-save.c giza-set-font.c giza-stroke.c \
        giza-subpanel.c giza-text-background.c giza-text.c giza-tick.c \
        giza-transforms.c giza-vector.c giza-viewport.c giza-version.c \
-       giza-warnings.c giza-window.c giza.c lex.yy.c \
+       giza-warnings.c giza-window.c giza.c lex.yy.c giza-itf.c\
        giza-arrow-style-private.h giza-driver-svg-private.h giza-stroke-private.h \
        giza-band-private.h giza-driver-xw-private.h giza-subpanel-private.h \
        giza-character-size-private.h giza-drivers-private.h giza-text-background-private.h \
@@ -33,7 +33,7 @@ libgiza_la_SOURCES = giza-annotate.c giza-arrow-style.c giza-arrow.c giza-axis.c
        giza-driver-null-private.h giza-private.h giza-viewport-private.h \
        giza-driver-pdf-private.h giza-render-private.h giza-warnings-private.h \
        giza-driver-png-private.h giza-set-font-private.h giza-window-private.h \
-       giza-driver-ps-private.h giza-shared.h giza.h
+       giza-driver-ps-private.h giza-shared.h giza.h giza-itf.h
 
 libgiza_la_CPPFLAGS = $(X11_CFLAGS) $(CAIRO_CFLAGS) $(FT_CFLAGS) $(FC_CFLAGS)
 

--- a/src/giza-colour-index.c
+++ b/src/giza-colour-index.c
@@ -427,31 +427,12 @@ _giza_init_colour_index (void)
 void
 giza_set_colour_index_range (int cimin, int cimax)
 {
-  if (cimin < GIZA_COLOUR_INDEX_MIN)
-    {
-      _giza_colour_index_min = GIZA_COLOUR_INDEX_MIN;
-    }
-   else if (cimin > GIZA_COLOUR_INDEX_MAX)
-    {
-      _giza_colour_index_min = GIZA_COLOUR_INDEX_MAX;
-    }
-   else
-    {
-      _giza_colour_index_min = cimin;
-    }
-
-  if (cimax < GIZA_COLOUR_INDEX_MIN)
-    {
-      _giza_colour_index_max = GIZA_COLOUR_INDEX_MIN;
-    }
-   else if (cimax > GIZA_COLOUR_INDEX_MAX)
-    {
-      _giza_colour_index_max = GIZA_COLOUR_INDEX_MAX;
-    }
-   else
-    {
-      _giza_colour_index_max = cimax;
-    }
+  /* constrain both colour indices to be within GIZA_COLOUR_INDEX_MIN, GIZA_COLOUR_INDEX_MAX */
+  _giza_colour_index_min = MAX(GIZA_COLOUR_INDEX_MIN, MIN(cimin, GIZA_COLOUR_INDEX_MAX));
+  _giza_colour_index_max = MIN(GIZA_COLOUR_INDEX_MAX, MAX(cimax, GIZA_COLOUR_INDEX_MIN));
+  /* Now make sure that colour_index_min <= colour_index_max */
+  _giza_colour_index_min = MIN(_giza_colour_index_min, _giza_colour_index_max);
+  _giza_colour_index_max = MAX(_giza_colour_index_min, _giza_colour_index_max);
 }
 
 /**

--- a/src/giza-colour-table.c
+++ b/src/giza-colour-table.c
@@ -110,8 +110,13 @@ giza_set_colour_table (const double *controlPoints, const double *red, const dou
   _giza_colour_table.n = tmpn;
    if (tmpn < n)
    {
-     _giza_warning ("giza_set_colour_table", "Invalid values for control points in colour table settings");
-     return 2;
+       /* require at least two valid control points in our table to remain! */
+       if( tmpn<2 ) {
+           _giza_warning ("giza_set_colour_table", "not enough valid control points in colour table remain after vetting");
+           return 2;
+       }
+       /* otherwise just issue a warning */
+       _giza_warning ("giza_set_colour_table", "%d invalid values for control points in colour table settings out of %d", tmpn, n);
    }
 
   /* use the installed colour table to set the colours of colour indices in the specified range */

--- a/src/giza-cpgplot.c
+++ b/src/giza-cpgplot.c
@@ -237,7 +237,7 @@ void cpgcons(const float *a, int idim, int jdim, int i1, int i2, \
 {
   float affine[6];
   convert_tr_to_affine(tr,affine);
-  giza_contour_float(idim,jdim,a,i1-1,i2-1,j1-1,j2-1,abs(nc),c,affine);
+  giza_contour_float(idim,jdim,a,i1-1,i2-1,j1-1,j2-1,nc,c,affine);
 }
 
 /***************************************************************
@@ -249,7 +249,7 @@ void cpgcont(const float *a, int idim, int jdim, int i1, int i2, \
 {
   float affine[6];
   convert_tr_to_affine(tr,affine);
-  giza_contour_float(idim,jdim,a,i1-1,i2-1,j1-1,j2-1,abs(nc),c,affine);
+  giza_contour_float(idim,jdim,a,i1-1,i2-1,j1-1,j2-1,nc,c,affine);
 }
 
 /***************************************************************
@@ -798,7 +798,7 @@ void cpgqinf(const char *item, char *value, int *value_length)
  ***************************************************************/
 void cpgqitf(int *itf)
 {
-
+	giza_get_image_transfer_function(itf);
 }
 
 /***************************************************************
@@ -1069,7 +1069,7 @@ void cpgshs(float angle, float sepn, float phase)
  ***************************************************************/
 void cpgsitf(int itf)
 {
-
+	giza_set_image_transfer_function(itf);
 }
 
 /***************************************************************

--- a/src/giza-fortran.F90
+++ b/src/giza-fortran.F90
@@ -148,6 +148,8 @@ module giza
       giza_set_window_equal_scale, &
       giza_get_window, &
       giza_format_number, &
+      giza_set_image_transfer_function, &
+      giza_get_image_transfer_function, &
       giza_query_device
 
 #include "giza-shared.h"
@@ -1718,6 +1720,21 @@ private
       integer(kind=c_int),intent(out) :: rval
     end function giza_query_device_c
  end interface
+
+ interface giza_set_image_transfer_function
+    subroutine giza_set_image_transfer_function(itf) bind(C)
+      import
+      integer(kind=c_int), value, intent(in) :: itf
+    end subroutine giza_set_image_transfer_function
+ end interface
+
+ interface giza_get_image_transfer_function
+    subroutine giza_get_image_transfer_function(itf) bind(C)
+      import
+      integer(kind=c_int), intent(out) :: itf
+    end subroutine giza_get_image_transfer_function
+ end interface
+
 !------------------ end of interfaces -----------------------
 
 contains
@@ -2021,6 +2038,7 @@ contains
     string = fstring(stringc)
 
   end subroutine giza_query_device_f2c
+
 
   !---------------------------------------------------------------------------
   !

--- a/src/giza-itf.c
+++ b/src/giza-itf.c
@@ -1,0 +1,168 @@
+/* giza - a scientific plotting library built on cairo
+ *
+ * Copyright (c) 2010      James Wetter and Daniel Price
+ * Copyright (c) 2010-2022 Daniel Price
+ *
+ * This library is free software; and you are welcome to redistribute
+ * it under the terms of the GNU General Public License
+ * (GPL, see LICENSE file for details) and the provision that
+ * this notice remains intact. If you modify this file, please
+ * note section 2a) of the GPLv2 states that:
+ *
+ *  a) You must cause the modified files to carry prominent notices
+ *     stating that you changed the files and the date of any change.
+ *
+ * This software is distributed "AS IS", with ABSOLUTELY NO WARRANTY.
+ * See the GPL for specific language governing rights and limitations.
+ *
+ * The Original code is the giza plotting library.
+ *
+ * Contributor(s):
+ *      James Wetter <wetter.j@gmail.com>
+ *      Daniel Price <daniel.price@monash.edu> (main contact)
+ *      Marjolein Verkouter <verkouter@jive.eu>
+ */
+#include "giza-itf.h"
+#include "giza-io-private.h"
+#include "giza-private.h"
+#include <giza.h>
+#include <math.h>
+
+
+double _giza_itf_linear(const double pixelvalue, const double vmin, const double vmax);
+double _giza_itf_log(const double pixelvalue, const double vmin, const double vmax);
+double _giza_itf_sqrt(const double pixelvalue, const double vmin, const double vmax);
+
+float  _giza_itf_linear_f(const float pixelvalue, const float vmin, const float vmax);
+float  _giza_itf_log_f(const float pixelvalue, const float vmin, const float vmax);
+float  _giza_itf_sqrt_f(const float pixelvalue, const float vmin, const float vmax);
+
+int    _giza_itf_idx_linear(const double pixelvalue, const double vmin, const double vmax, const int cimin, const int cimax);
+int    _giza_itf_idx_log(const double pixelvalue, const double vmin, const double vmax, const int cimin, const int cimax);
+int    _giza_itf_idx_sqrt(const double pixelvalue, const double vmin, const double vmax, const int cimin, const int cimax);
+
+int     _giza_itf_idx_linear_f(const float pixelvalue, const float vmin, const float vmax, const int cimin, const int cimax);
+int     _giza_itf_idx_log_f(const float pixelvalue, const float vmin, const float vmax, const int cimin, const int cimax);
+int     _giza_itf_idx_sqrt_f(const float pixelvalue, const float vmin, const float vmax, const int cimin, const int cimax);
+
+/* We keep an array of three image transfer functions, use set_image_transfer_function to set
+	0: linear
+	1: log
+	2: sqrt 
+*/
+giza_itf_type       giza_itf[3]       = {_giza_itf_linear,       _giza_itf_log,       _giza_itf_sqrt};
+giza_itf_type_f     giza_itf_f[3]     = {_giza_itf_linear_f,     _giza_itf_log_f,     _giza_itf_sqrt_f};
+giza_itf_idx_type   giza_itf_idx[3]   = {_giza_itf_idx_linear,   _giza_itf_idx_log,   _giza_itf_idx_sqrt};
+giza_itf_idx_type_f giza_itf_idx_f[3] = {_giza_itf_idx_linear_f, _giza_itf_idx_log_f, _giza_itf_idx_sqrt_f};
+
+
+void giza_set_image_transfer_function(int itf) {
+  if (!_giza_check_device_ready ("giza_set_image_transfer_function"))
+    return;
+  if (itf < 0 || itf > 2)
+    {
+      _giza_warning ("giza_set_image_transfer_function",
+		    "Invalid image transfer function, not set");
+      return;
+    }
+  Dev[id].itf = itf;
+}
+
+void giza_get_image_transfer_function(int* itfp) {
+  if (!_giza_check_device_ready ("giza_get_image_transfer_function"))
+    return;
+  *itfp = Dev[id].itf;
+}
+
+
+/*
+ * Lifted from PGPLOT grimg2.f on how to handle the image transfer function:
+	
+	SFAC  = 65000.0
+	SFACL = LOG(1.0+SFAC)
+	...
+        IF (MODE.EQ.0) THEN
+        	IV = NINT((MININD*(A2-AV) + MAXIND*(AV-A1))/(A2-A1))
+        ELSE IF (MODE.EQ.1) THEN
+        	IV = MININD + NINT((MAXIND-MININD)*
+               			   LOG(1.0+SFAC*ABS((AV-A1)/(A2-A1)))/SFACL)
+        ELSE IF (MODE.EQ.2) THEN
+        	IV = MININD + NINT((MAXIND-MININD)*
+                                   SQRT(ABS((AV-A1)/(A2-A1))))
+        ELSE
+        	IV = MININD
+*/
+
+/* The linear transfer functions */
+
+/* returns position of pixelvalue as fraction of the distance between vmin, vmax */
+double _giza_itf_linear(const double pixelvalue, const double vmin, const double vmax) {
+    return (vmax > vmin) ? (MIN(vmax, MAX(vmin, pixelvalue))-vmin)/(vmax-vmin) : (MIN(vmin, MAX(vmax, pixelvalue))-vmax)/(vmin-vmax);
+}
+
+/* maps pixelvalue's fractional position between vmin, vmax to corresponding index between cimin, cimax */
+int  _giza_itf_idx_linear(const double pixelvalue, const double vmin, const double vmax, const int cimin, const int cimax) {
+    const double fractional_pos = _giza_itf_linear(pixelvalue, vmin, vmax);
+    return MIN(cimin, cimax) + (int) round(((cimin < cimax) ? (cimax-cimin) : (cimin - cimax)) * fractional_pos);
+}
+
+/* id. for floats */
+float _giza_itf_linear_f(const float pixelvalue, const float vmin, const float vmax) {
+    return (vmax > vmin) ? (MIN(vmax, MAX(vmin, pixelvalue))-vmin)/(vmax-vmin) : (MIN(vmin, MAX(vmax, pixelvalue))-vmax)/(vmin-vmax);
+}
+
+int  _giza_itf_idx_linear_f(const float pixelvalue, const float vmin, const float vmax, const int cimin, const int cimax) {
+    const float fractional_pos = _giza_itf_linear_f(pixelvalue, vmin, vmax);
+    return MIN(cimin, cimax) + (int)roundf(((cimin < cimax) ? (cimax-cimin) : (cimin - cimax)) * fractional_pos);
+}
+
+/* The log transfer functions */
+const double sfac    = 65000.0;
+
+/* returns position of pixelvalue as fraction of the distance between vmin, vmax */
+double _giza_itf_log(const double pixelvalue, const double vmin, const double vmax) {
+    double sfacl = log(1.0+sfac);
+    return log(1.0+sfac*fabs(((vmax > vmin) ? (MIN(vmax, MAX(vmin, pixelvalue))-vmin) : (MIN(vmin, MAX(vmax, pixelvalue))-vmax))/(vmax-vmin)))/sfacl;
+}
+
+/* maps pixelvalue's fractional position between vmin, vmax to corresponding index between cimin, cimax */
+int  _giza_itf_idx_log(const double pixelvalue, const double vmin, const double vmax, const int cimin, const int cimax) {
+    const double fractional_pos = _giza_itf_log(pixelvalue, vmin, vmax);
+    return MIN(cimin, cimax) + (int)round(((cimax > cimin) ? (cimax-cimin) : (cimin-cimax)) * fractional_pos);
+}
+
+/* id. for floats */
+const double sfac_f  = 65000.0f;
+
+float _giza_itf_log_f(const float pixelvalue, const float vmin, const float vmax) {
+    float sfacl_f = logf(1.0f+sfac);
+    return log(1.0f+sfac_f*fabsf(((vmax > vmin) ? (MIN(vmax, MAX(vmin, pixelvalue))-vmin) : (MIN(vmin, MAX(vmax, pixelvalue))-vmax))/(vmax-vmin)))/sfacl_f;
+}
+
+int  _giza_itf_idx_log_f(const float pixelvalue, const float vmin, const float vmax, const int cimin, const int cimax) {
+    const float fractional_pos = _giza_itf_log_f(pixelvalue, vmin, vmax);
+    return MIN(cimin, cimax) + (int)roundf(((cimax > cimin) ? (cimax-cimin) : (cimin-cimax)) * fractional_pos);
+}
+
+/* and the sqrt versions */
+
+/* returns position of pixelvalue as fraction of the distance between vmin, vmax */
+double _giza_itf_sqrt(const double pixelvalue, const double vmin, const double vmax) {
+    return sqrt( _giza_itf_linear(pixelvalue, vmin, vmax) );
+}
+
+/* maps pixelvalue's fractional position between vmin, vmax to corresponding index between cimin, cimax */
+int  _giza_itf_idx_sqrt(const double pixelvalue, const double vmin, const double vmax, const int cimin, const int cimax) {
+    const double fractional_pos = _giza_itf_sqrt(pixelvalue, vmin, vmax);
+    return MIN(cimin, cimax) + (int)round(((cimax > cimin) ? (cimax-cimin) : (cimin-cimax)) * fractional_pos);
+}
+
+/* id. for floats */
+float _giza_itf_sqrt_f(const float pixelvalue, const float vmin, const float vmax) {
+    return sqrtf( _giza_itf_linear_f(pixelvalue, vmin, vmax) );
+}
+
+int  _giza_itf_idx_sqrt_f(const float pixelvalue, const float vmin, const float vmax, const int cimin, const int cimax) {
+    const float fractional_pos = _giza_itf_sqrt_f(pixelvalue, vmin, vmax);
+    return MIN(cimin, cimax) + (int)roundf(((cimax > cimin) ? (cimax-cimin) : (cimin-cimax)) * fractional_pos);
+}

--- a/src/giza-itf.h
+++ b/src/giza-itf.h
@@ -1,0 +1,63 @@
+/* giza - a scientific plotting library built on cairo
+ *
+ * Copyright (c) 2010      James Wetter and Daniel Price
+ * Copyright (c) 2010-2022 Daniel Price
+ *
+ * This library is free software; and you are welcome to redistribute
+ * it under the terms of the GNU General Public License
+ * (GPL, see LICENSE file for details) and the provision that
+ * this notice remains intact. If you modify this file, please
+ * note section 2a) of the GPLv2 states that:
+ *
+ *  a) You must cause the modified files to carry prominent notices
+ *     stating that you changed the files and the date of any change.
+ *
+ * This software is distributed "AS IS", with ABSOLUTELY NO WARRANTY.
+ * See the GPL for specific language governing rights and limitations.
+ *
+ * The Original code is the giza plotting library.
+ *
+ * Contributor(s):
+ *      James Wetter <wetter.j@gmail.com>
+ *      Daniel Price <daniel.price@monash.edu> (main contact)
+ *      Marjolein Verkouter <verkouter@jive.eu>
+ */
+#ifndef GIZA_ITF_H
+#define GIZA_ITF_H
+
+/* support image transfer functions */
+
+/*
+ * Lifted from PGPLOT grimg2.f on how to handle the image transfer function:
+	
+	SFAC  = 65000.0
+	SFACL = LOG(1.0+SFAC)
+	...
+        IF (MODE.EQ.0) THEN
+        	IV = NINT((MININD*(A2-AV) + MAXIND*(AV-A1))/(A2-A1))
+        ELSE IF (MODE.EQ.1) THEN
+        	IV = MININD + NINT((MAXIND-MININD)*
+               			   LOG(1.0+SFAC*ABS((AV-A1)/(A2-A1)))/SFACL)
+        ELSE IF (MODE.EQ.2) THEN
+        	IV = MININD + NINT((MAXIND-MININD)*
+                                   SQRT(ABS((AV-A1)/(A2-A1))))
+        ELSE
+        	IV = MININD
+*/
+
+typedef double (*giza_itf_type)(const double pixelvalue, const double vmin, const double vmax);
+typedef float  (*giza_itf_type_f)(const float pixelvalue, const float vmin, const float vmax);
+typedef int    (*giza_itf_idx_type)(const double pixelvalue, const double vmin, const double vmax, const int cimin, const int cimax);
+typedef int    (*giza_itf_idx_type_f)(const float pixelvalue, const float vmin, const float vmax, const int cimin, const int cimax);
+
+/* We keep an array of three image transfer functions, use set_image_transfer_function to set
+	0: linear
+	1: log
+	2: sqrt 
+*/
+extern giza_itf_type       giza_itf[3];
+extern giza_itf_type_f     giza_itf_f[3];
+extern giza_itf_idx_type   giza_itf_idx[3];
+extern giza_itf_idx_type_f giza_itf_idx_f[3];
+
+#endif

--- a/src/giza-pgplot.f90
+++ b/src/giza-pgplot.f90
@@ -329,7 +329,7 @@ subroutine PGCONT (A, IDIM, JDIM, I1, I2, J1, J2, C, NC, TR)
  real                :: affine(6)
 
  call convert_tr_to_affine(tr,affine)
- call giza_contour(idim,jdim,a,i1-1,i2-1,j1-1,j2-1,abs(nc),C,affine)
+ call giza_contour(idim,jdim,a,i1-1,i2-1,j1-1,j2-1,nc,C,affine)
 
 end subroutine PGCONT
 
@@ -1155,8 +1155,11 @@ end subroutine PGQINF
 ! Status: NOT IMPLEMENTED
 !------------------------------------------------------------------------
 subroutine PGQITF (ITF)
+ use giza, only:giza_get_image_transfer_function
  implicit none
  integer, intent(out) :: ITF
+
+ call giza_get_image_transfer_function(ITF)
 
 end subroutine PGQITF
 
@@ -1531,8 +1534,11 @@ end subroutine PGSHS
 ! Status: NOT IMPLEMENTED
 !------------------------------------------------------------------------
 subroutine PGSITF (ITF)
+ use giza, only:giza_set_image_transfer_function
  implicit none
  integer, intent(in) :: ITF
+
+ call giza_set_image_transfer_function(ITF)
 
 end subroutine PGSITF
 

--- a/src/giza-private.h
+++ b/src/giza-private.h
@@ -129,6 +129,7 @@ typedef struct
   double fontAngle;
   int number_format;
   giza_callback_t motion_callback;
+  int itf; /* image transfer function */
 } giza_device_t;
 
 extern giza_device_t Dev[GIZA_MAX_DEVICES];

--- a/src/giza-render-private.h
+++ b/src/giza-render-private.h
@@ -25,6 +25,7 @@
 static void _giza_colour_pixel (unsigned char *array, int pixNum, double pos);
 static void _giza_colour_pixel_transparent (unsigned char *array, int pixNum, double pos);
 static void _giza_colour_pixel_alpha (unsigned char *array, int pixNum, double pos, double alpha);
+static void _giza_colour_pixel_index_alpha (unsigned char *array, int pixNum, int ci, double alpha);
 void _giza_render (int sizex, int sizey, const double* data, int i1, int i2,
 	           int j1, int j2, double valMin, double valMax, const double *affine,
                    int transparent, int extend, const double* datalpha);

--- a/src/giza.h
+++ b/src/giza.h
@@ -379,3 +379,6 @@ void giza_set_window_equal_scale_float (float x1, float x2, float y1,
 					float y2);
 void giza_get_window (double *x1, double *x2, double *y1, double *y2);
 void giza_get_window_float (float *x1, float *x2, float *y1, float *y2);
+
+void giza_set_image_transfer_function(int itf);
+void giza_get_image_transfer_function(int* itfp);


### PR DESCRIPTION
Hi @danieljprice!

I've taken a stab at supporting image transfer functions. I've used `pgdemo4` (the example program using PGIMAG) and added a `CALL PGSITF(1)` in there to be able to test the behaviour of PGPLOT and Giza. See attached screenshot for the comparison.

Currently the renderer is PGPLOT compliant: it uses the colour indices set by `PGCTAB` and `PGSCIR` (install a colour table and compute the colours for the current set range of colour indices). The old code use "true colour" rendering - each individual pixel was converted to an interpolated colour based on the installed colour table.

I have an idea to support both methods - calling the `giza_render()` function can return to the old "true colour" behaviour and for the `PGPLOT` interface it can use the "new" method: translate each pixel's colour to the nearest colour index. That way your `splash` code calling the routines directly remain unaffected and the PGPLOT API becomes more PGPLOT in behaviour.

This edit also introduces the "automatic line style choice" as documented in `PGCONT`; removing the `abs(nc[ontour])` before calling the Giza routine and handling the + and - cases of that value accordingly.

Because this one adds a new dependency (`src/giza-itf.{h,c}`) I edited `src/Makefile.am`, which means that you need to re-run `automake`. The `automake` on my own system is older than the version that created the `*.in` files in the repo so I did not commit those.
Cheers!
M
![Screenshot 2022-08-01 at 15 34 16](https://user-images.githubusercontent.com/14309703/182163252-6d0986cd-97ee-49ad-b1ea-4e4092780023.png)