### PR TITLE
Potential fix for code scanning alert no. 11: Multiplication result converted to larger type

### DIFF
--- a/src/giza-render.c
+++ b/src/giza-render.c
@@ -163,7 +163,7 @@ _giza_render (int sizex, int sizey, const double* data, int i1, int i2,
 #else
   stride = 4*width;
 #endif
-  pixdata = malloc (stride * height);
+  pixdata = malloc ((size_t) stride * (size_t) height);
   if (!pixdata)
     {
       _giza_warning ("giza_render", "Allocation failed, skipping render.");


### PR DESCRIPTION
Potential fix for [https://github.com/danieljprice/giza/security/code-scanning/11](https://github.com/danieljprice/giza/security/code-scanning/11)

The fix is to ensure multiplication is performed in `size_t` (or otherwise overflow-checked) before calling `malloc`.  
Best minimal fix without changing behavior: cast operands to `size_t` in the allocation expression so arithmetic is widened before multiplication.

In `src/giza-render.c`, replace:
- `pixdata = malloc (stride * height);`

with:
- `pixdata = malloc ((size_t) stride * (size_t) height);`

No new imports are needed (`size_t` is already available via existing standard headers in this translation unit context).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
