### PR TITLE
Potential fix for code scanning alert no. 8: Multiplication result converted to larger type

### DIFF
--- a/src/giza-points.c
+++ b/src/giza-points.c
@@ -551,8 +551,8 @@ static void
 _giza_triangle(double x, double y, int fill, int updown, float scale, float offset_fraction)
 {
   cairo_new_sub_path (Dev[id].context);
-  cairo_move_to (Dev[id].context, x - markerHeight * scale, y - offset_fraction * updown * markerHeight * scale);
-  cairo_line_to (Dev[id].context, x + markerHeight * scale, y - offset_fraction * updown * markerHeight * scale);
+  cairo_move_to (Dev[id].context, x - markerHeight * scale, y - (double)offset_fraction * (double)updown * markerHeight * scale);
+  cairo_line_to (Dev[id].context, x + markerHeight * scale, y - (double)offset_fraction * (double)updown * markerHeight * scale);
   cairo_line_to (Dev[id].context, x, y + updown * markerHeight * scale);
   cairo_close_path (Dev[id].context);
   if (fill) { cairo_fill(Dev[id].context); }


### PR DESCRIPTION
Potential fix for [https://github.com/danieljprice/giza/security/code-scanning/8](https://github.com/danieljprice/giza/security/code-scanning/8)

To fix this class of issue, ensure at least one operand is converted to the wider type **before** multiplication, so the multiplication is evaluated in that wider type.

Best fix here: in `src/giza-points.c`, function `_giza_triangle` (around lines 554–556), cast `offset_fraction` and/or `updown` to `double` in the two expressions that currently use `offset_fraction * updown * ...`. This guarantees evaluation in `double` for the intermediate product and avoids the CodeQL warning, while preserving existing numeric behavior.

No new imports, helper methods, or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
