### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -1,5 +1,7 @@
 name: Update API docs
 on: push
+permissions:
+  contents: write
 jobs:
   report:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,8 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
+permissions:
+  contents: read
 jobs:
   build:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Potential fix for [https://github.com/danieljprice/giza/security/code-scanning/2](https://github.com/danieljprice/giza/security/code-scanning/2)

Add an explicit `permissions` block to the workflow (or job). Since this workflow commits generated docs back to the repository, it requires `contents: write`. The best minimal, behavior-preserving fix is to define workflow-level permissions:

- `contents: write` (required for commit/push by `EndBug/add-and-commit`).

This both resolves the CodeQL finding and documents intended token scope.  
Change only `.github/workflows/api.yml`, near the top-level keys (after `on:` is a clean location). No imports/dependencies/method changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
