### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,9 @@ on:
     tags:
     - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
 
+permissions:
+  contents: write
+
 jobs:
   release:
     strategy:


### PR DESCRIPTION
Potential fix for [https://github.com/danieljprice/giza/security/code-scanning/1](https://github.com/danieljprice/giza/security/code-scanning/1)

Add an explicit `permissions` block to the workflow (or the specific job) defining only the scopes required.  
For this workflow, the `release` job creates a release and uploads a release asset, which requires `contents: write`. No other explicit scopes are necessary based on the shown steps.

Best fix with minimal functional change:
- Edit `.github/workflows/release.yml`.
- Add a top-level `permissions` block after the trigger (`on:`) and before `jobs:`.
- Set:
  - `contents: write`

This keeps behavior intact (release creation/upload still works) while removing reliance on potentially over-permissive defaults.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
