### PR TITLE
Add rubber-band cursor support to /osx driver (CoreGraphics overlay)

### DIFF
--- a/src/giza-cpgplot.c
+++ b/src/giza-cpgplot.c
@@ -34,6 +34,7 @@
 #include "giza-io-private.h" /* for _giza_error() */
 #include "giza-driver-xw-private.h"
 #include "giza-driver-eps-private.h"
+#include "giza-driver-osxcocoa-private.h"
 #include "cpgplot.h"
 #include <string.h>
 #include <strings.h> /* for strcasecmp */
@@ -906,6 +907,9 @@ void cpgqdt(int n, char *type, int *type_length, char *descr, \
   static const struct { const char *type; const char *descr; int inter; } devs[] = {
 #ifdef _GIZA_HAS_XW
     {"/xw",   "X Window (interactive)", 1},
+#endif
+#ifdef _GIZA_HAS_OSXCOCOA
+    {"/osx",  "macOS native window (interactive)", 1},
 #endif
     {"/png",  "PNG file",               0},
     {"/pdf",  "PDF file",               0},

--- a/src/giza-driver-osxcocoa-bridge.c
+++ b/src/giza-driver-osxcocoa-bridge.c
@@ -42,6 +42,7 @@
 #include <stdio.h>
 #include "giza-driver-osxcocoa-private.h"
 #include "giza-transforms-private.h"
+#include "giza-band-private.h"
 
 #include <giza.h>
 #include <stdlib.h>
@@ -202,13 +203,20 @@ _giza_get_key_press_osxcocoa (int mode, int moveCurs,
                           const double *xanc, const double *yanc,
                           double *x, double *y, char *ch)
 {
-    (void)mode; (void)moveCurs; (void)nanc; (void)xanc; (void)yanc;
-
     int oldTrans = _giza_get_trans();
     _giza_set_trans(GIZA_TRANS_WORLD);
 
+    /* Convert anchor world coords → device (surface) coords for the band overlay */
+    double axd = xanc[0], ayd = yanc[0];
+    cairo_user_to_device(Dev[id].context, &axd, &ayd);
+
     float fx, fy;
-    _giza_osxcocoa_wait_for_event(id, &fx, &fy, ch);
+    /* attach + wait + detach をmainスレッドで一括処理してデッドロック回避 */
+    if (mode > 0) {
+        _giza_osxcocoa_wait_for_event_band(id, mode, (float)axd, (float)ayd, &fx, &fy, ch);
+    } else {
+        _giza_osxcocoa_wait_for_event(id, &fx, &fy, ch);
+    }
 
     *x = (double)fx;
     *y = (double)fy;
@@ -222,7 +230,19 @@ _giza_get_key_press_osxcocoa (int mode, int moveCurs,
 int
 _giza_init_band_osxcocoa (void)
 {
-    return 0;   /* rubber-band not yet implemented */
+    /* We don't use Cairo Band.box/Band.restore for the OSX driver.
+     * Instead GizaBandView draws directly via CoreGraphics.
+     * However _giza_init_band() in giza-drivers.c will try to use Band.box
+     * after calling us, so we must provide a valid (dummy) cairo context. */
+    int w = Dev[id].width  > 0 ? Dev[id].width  : 1;
+    int h = Dev[id].height > 0 ? Dev[id].height : 1;
+    cairo_surface_t *dummy = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, w, h);
+    Band.onscreen = dummy;
+    Band.box      = cairo_create(dummy);
+    Band.restore  = cairo_create(dummy);
+    Band.maxWidth  = w;
+    Band.maxHeight = h;
+    return 1; /* success */
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/giza-driver-osxcocoa-bridge.c
+++ b/src/giza-driver-osxcocoa-bridge.c
@@ -213,6 +213,9 @@ _giza_get_key_press_osxcocoa (int mode, int moveCurs,
     float fx, fy;
     /* attach + wait + detach をmainスレッドで一括処理してデッドロック回避 */
     if (mode > 0) {
+        /* Convert anchor world coords → device (surface) coords for the band overlay */
+        double axd = xanc[0], ayd = yanc[0];
+        cairo_user_to_device(Dev[id].context, &axd, &ayd);
         _giza_osxcocoa_wait_for_event_band(id, mode, (float)axd, (float)ayd, &fx, &fy, ch);
     } else {
         _giza_osxcocoa_wait_for_event(id, &fx, &fy, ch);
@@ -237,6 +240,7 @@ _giza_init_band_osxcocoa (void)
     int w = Dev[id].width  > 0 ? Dev[id].width  : 1;
     int h = Dev[id].height > 0 ? Dev[id].height : 1;
     cairo_surface_t *dummy = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, w, h);
+    if (cairo_surface_status(dummy) != CAIRO_STATUS_SUCCESS) return 0;
     Band.onscreen = dummy;
     Band.box      = cairo_create(dummy);
     Band.restore  = cairo_create(dummy);

--- a/src/giza-driver-osxcocoa-private.h
+++ b/src/giza-driver-osxcocoa-private.h
@@ -58,6 +58,9 @@ GizaCGContextRef _giza_osxcocoa_clear_and_get_context(int devId, int width, int 
 void         _giza_osxcocoa_close_window         (int devId);
 void         _giza_osxcocoa_wait_for_event       (int devId,
                                              float *x, float *y, char *ch);
+void         _giza_osxcocoa_wait_for_event_band  (int devId, int mode,
+                                             float xancSurface, float yancSurface,
+                                             float *x, float *y, char *ch);
 
 /* ---- resize callback (implemented in giza-driver-osxcocoa-bridge.c) ---------- */
 /* Called by GizaView -setFrameSize: */

--- a/src/giza-driver-osxcocoa.m
+++ b/src/giza-driver-osxcocoa.m
@@ -658,7 +658,6 @@ _giza_osxcocoa_wait_for_event_band(int devId, int mode,
     GizaView *view = _osxcocoa_view[devId];
     __block NSPoint pt = NSZeroPoint;
     __block char c = ' ';
-    dispatch_semaphore_t sem = dispatch_semaphore_create(0);
     _run_on_main(^{
         NSPoint anc = NSMakePoint(xancSurface, yancSurface);
         [view attachBandViewMode:mode anchorSurfacePt:anc];

--- a/src/giza-driver-osxcocoa.m
+++ b/src/giza-driver-osxcocoa.m
@@ -70,6 +70,156 @@
 /* GizaView                                                                  */
 /* ======================================================================== */
 
+/* ======================================================================== */
+/* GizaBandView — transparent overlay that draws rubber-band shapes         */
+/* using CoreGraphics. Lives on top of GizaView; only exists during         */
+/* a giza_band() / PGBAND call.                                              */
+/* ======================================================================== */
+
+@interface GizaBandView : NSView
+{
+    int     _mode;       /* GIZA_BAND_* mode */
+    NSPoint _anchor;     /* anchor point in surface coords */
+    NSPoint _cursor;     /* current cursor in surface coords */
+    int     _surfW;      /* source surface size (for full-width lines) */
+    int     _surfH;
+    CGRect  _displayRect;/* same letterbox rect as parent GizaView */
+}
+- (instancetype)initWithFrame:(NSRect)frame
+                         mode:(int)mode
+                       anchor:(NSPoint)anc
+                      surfaceSize:(NSSize)ss
+                      displayRect:(CGRect)dr;
+- (void)updateCursor:(NSPoint)surfPt displayRect:(CGRect)dr;
+@end
+
+@implementation GizaBandView
+
+- (instancetype)initWithFrame:(NSRect)frame
+                         mode:(int)mode
+                       anchor:(NSPoint)anc
+                      surfaceSize:(NSSize)ss
+                      displayRect:(CGRect)dr
+{
+    self = [super initWithFrame:frame];
+    if (self) {
+        _mode = mode;
+        _anchor = anc;
+        _cursor = anc;
+        _surfW  = (int)ss.width;
+        _surfH  = (int)ss.height;
+        _displayRect = dr;
+    }
+    return self;
+}
+
+- (BOOL)isOpaque { return NO; }
+- (BOOL)acceptsFirstResponder { return NO; }  /* events handled by GizaView */
+
+/* Convert a surface-space point to view-space for drawing */
+- (CGPoint)_viewPtFromSurface:(NSPoint)sp
+{
+    if (_surfW <= 0 || _surfH <= 0 || _displayRect.size.width < 1)
+        return CGPointMake(sp.x, sp.y);
+    CGFloat sx = _displayRect.origin.x + sp.x / _surfW * _displayRect.size.width;
+    CGFloat sy = _displayRect.origin.y + sp.y / _surfH * _displayRect.size.height;
+    return CGPointMake(sx, sy);
+}
+
+- (void)drawRect:(NSRect)dirtyRect
+{
+    CGContextRef ctx = [[NSGraphicsContext currentContext] CGContext];
+    CGContextClearRect(ctx, NSRectToCGRect(self.bounds));
+
+    if (_mode <= 0) return;
+
+    /* Style: white line with 40% opacity fill for area modes */
+    CGContextSetLineWidth(ctx, 1.5);
+    CGContextSetRGBStrokeColor(ctx, 0.9, 0.9, 0.9, 1.0);
+    CGContextSetRGBFillColor  (ctx, 1.0, 1.0, 1.0, 0.15);
+
+    CGPoint a = [self _viewPtFromSurface:_anchor];
+    CGPoint c = [self _viewPtFromSurface:_cursor];
+
+    /* full-width / full-height extent in view coords */
+    CGPoint tl = [self _viewPtFromSurface:NSMakePoint(0,0)];
+    CGPoint br = [self _viewPtFromSurface:NSMakePoint(_surfW,_surfH)];
+
+    switch (_mode) {
+        case 1: /* line anchor → cursor */
+            CGContextMoveToPoint(ctx, a.x, a.y);
+            CGContextAddLineToPoint(ctx, c.x, c.y);
+            CGContextStrokePath(ctx);
+            break;
+        case 2: /* hollow rectangle */
+            {
+                CGRect r = CGRectMake(fmin(a.x,c.x), fmin(a.y,c.y),
+                                      fabs(c.x-a.x), fabs(c.y-a.y));
+                CGContextFillRect(ctx, r);
+                CGContextStrokeRect(ctx, r);
+            }
+            break;
+        case 3: /* two horizontal lines */
+            CGContextMoveToPoint(ctx, tl.x, a.y);
+            CGContextAddLineToPoint(ctx, br.x, a.y);
+            CGContextMoveToPoint(ctx, tl.x, c.y);
+            CGContextAddLineToPoint(ctx, br.x, c.y);
+            CGContextStrokePath(ctx);
+            break;
+        case 4: /* two vertical lines */
+            CGContextMoveToPoint(ctx, a.x, tl.y);
+            CGContextAddLineToPoint(ctx, a.x, br.y);
+            CGContextMoveToPoint(ctx, c.x, tl.y);
+            CGContextAddLineToPoint(ctx, c.x, br.y);
+            CGContextStrokePath(ctx);
+            break;
+        case 5: /* single horizontal line */
+            CGContextMoveToPoint(ctx, tl.x, c.y);
+            CGContextAddLineToPoint(ctx, br.x, c.y);
+            CGContextStrokePath(ctx);
+            break;
+        case 6: /* single vertical line */
+            CGContextMoveToPoint(ctx, c.x, tl.y);
+            CGContextAddLineToPoint(ctx, c.x, br.y);
+            CGContextStrokePath(ctx);
+            break;
+        case 7: /* crosshair */
+            CGContextMoveToPoint(ctx, tl.x, c.y);
+            CGContextAddLineToPoint(ctx, br.x, c.y);
+            CGContextMoveToPoint(ctx, c.x, tl.y);
+            CGContextAddLineToPoint(ctx, c.x, br.y);
+            CGContextStrokePath(ctx);
+            break;
+        case 8: /* circle centred on anchor */
+            {
+                CGFloat dx = c.x - a.x, dy = c.y - a.y;
+                CGFloat r  = sqrt(dx*dx + dy*dy);
+                CGContextBeginPath(ctx);
+                CGContextAddArc(ctx, a.x, a.y, r, 0, 2*M_PI, 0);
+                CGContextFillPath(ctx);
+                CGContextBeginPath(ctx);
+                CGContextAddArc(ctx, a.x, a.y, r, 0, 2*M_PI, 0);
+                CGContextStrokePath(ctx);
+            }
+            break;
+        default:
+            break;
+    }
+}
+
+- (void)updateCursor:(NSPoint)surfPt displayRect:(CGRect)dr
+{
+    _cursor = surfPt;
+    _displayRect = dr;
+    [self setNeedsDisplay:YES];
+}
+
+@end
+
+/* ======================================================================== */
+/* GizaView                                                                  */
+/* ======================================================================== */
+
 @interface GizaView : NSView
 {
     CGLayerRef     _layer;
@@ -83,16 +233,25 @@
     int            _pixelStride;
     /* リサイズ表示用: drawRect が描画する実際の矩形 (letterbox/pillarbox) */
     CGRect         _displayRect;
+    /* rubber-band overlay */
+    GizaBandView  *_bandView;
+    BOOL           _bandActive;
+    NSPoint        _bandMovePt;   /* most recent mouse-moved surface point */
+    BOOL           _gotMouseMove;
 }
 - (instancetype)initWithFrame:(NSRect)frame devId:(int)devId;
 - (CGLayerRef)cgLayer;
 - (void)rebuildLayerSize:(NSSize)sz;
 - (void)waitForInputEvent;
+- (void)waitForInputEventWithBand;
 - (NSPoint)lastEventPoint;
 - (char)lastEventChar;
 - (void)setPixelData:(unsigned char*)data width:(int)w height:(int)h stride:(int)s;
 /* view 座標 → cairo surface 座標への逆変換 */
 - (NSPoint)surfacePointFromViewPoint:(NSPoint)vp;
+/* band control */
+- (void)attachBandViewMode:(int)mode anchorSurfacePt:(NSPoint)anc;
+- (void)detachBandView;
 @end
 
 @implementation GizaView
@@ -104,6 +263,8 @@
         _devId = devId; _layer = NULL; _gotEvent = NO; _eventCh = ' ';
         _pixelData = NULL; _pixelWidth = _pixelHeight = _pixelStride = 0;
         _displayRect = CGRectZero;
+        _bandView = nil; _bandActive = NO;
+        _bandMovePt = NSZeroPoint; _gotMouseMove = NO;
     }
     return self;
 }
@@ -225,6 +386,59 @@
                                            dequeue:YES];
         if (ev) [NSApp sendEvent:ev];
     }
+}
+
+/* Band-aware event loop: also handles mouse-moved events to update band */
+- (void)waitForInputEventWithBand {
+    _gotEvent = NO;
+    [[self window] setAcceptsMouseMovedEvents:YES];
+    while (!_gotEvent) {
+        /* distantFutureでブロックするとdispatch_asyncブロック内でRunLoopが詰まる。
+         * 短いタイムアウトでRunLoopを回し続けることで回避する。 */
+        [[NSRunLoop currentRunLoop] runMode:NSDefaultRunLoopMode
+                                 beforeDate:[NSDate dateWithTimeIntervalSinceNow:0.05]];
+        NSEvent *ev;
+        while ((ev = [NSApp nextEventMatchingMask:NSEventMaskAny
+                                       untilDate:[NSDate distantPast]
+                                          inMode:NSDefaultRunLoopMode
+                                         dequeue:YES])) {
+            if (ev.type == NSEventTypeMouseMoved ||
+                ev.type == NSEventTypeLeftMouseDragged) {
+                NSPoint vp = [self convertPoint:[ev locationInWindow] fromView:nil];
+                NSPoint sp = [self surfacePointFromViewPoint:vp];
+                [_bandView updateCursor:sp displayRect:_displayRect];
+                [_bandView displayIfNeeded];
+            } else {
+                [NSApp sendEvent:ev];
+            }
+        }
+    }
+    [[self window] setAcceptsMouseMovedEvents:NO];
+}
+
+/* Attach a GizaBandView overlay */
+- (void)attachBandViewMode:(int)mode anchorSurfacePt:(NSPoint)anc
+{
+    [self detachBandView];
+    NSSize ss = NSMakeSize(_pixelWidth > 0 ? _pixelWidth : (int)self.bounds.size.width,
+                           _pixelHeight > 0 ? _pixelHeight : (int)self.bounds.size.height);
+    _bandView = [[GizaBandView alloc]
+                    initWithFrame:self.bounds
+                             mode:mode
+                           anchor:anc
+                      surfaceSize:ss
+                      displayRect:_displayRect];
+    [self addSubview:_bandView];
+    _bandActive = YES;
+}
+
+- (void)detachBandView
+{
+    if (_bandView) {
+        [_bandView removeFromSuperview];
+        _bandView = nil;
+    }
+    _bandActive = NO;
 }
 
 - (NSPoint)surfacePointFromViewPoint:(NSPoint)vp
@@ -432,6 +646,28 @@ _giza_osxcocoa_wait_for_event(int devId, float *x, float *y, char *ch)
         dispatch_semaphore_wait(sem, DISPATCH_TIME_FOREVER);
         *x=(float)pt.x; *y=(float)pt.y; *ch=c;
     }
+}
+
+/* attach + wait + detach を全てmainスレッドで一括実行することでデッドロックを回避 */
+void
+_giza_osxcocoa_wait_for_event_band(int devId, int mode,
+                                   float xancSurface, float yancSurface,
+                                   float *x, float *y, char *ch)
+{
+    if (!_osxcocoa_inuse[devId]) { *ch='q'; return; }
+    GizaView *view = _osxcocoa_view[devId];
+    __block NSPoint pt = NSZeroPoint;
+    __block char c = ' ';
+    dispatch_semaphore_t sem = dispatch_semaphore_create(0);
+    _run_on_main(^{
+        NSPoint anc = NSMakePoint(xancSurface, yancSurface);
+        [view attachBandViewMode:mode anchorSurfacePt:anc];
+        [view waitForInputEventWithBand];
+        pt = [view lastEventPoint];
+        c  = [view lastEventChar];
+        [view detachBandView];
+    });
+    *x = (float)pt.x; *y = (float)pt.y; *ch = c;
 }
 
 #endif /* CAIRO_HAS_QUARTZ_SURFACE */

--- a/src/giza-drivers.c
+++ b/src/giza-drivers.c
@@ -850,8 +850,10 @@ _giza_get_key_press (int mode, int moveCurs, int nanc, const double *xanch, cons
 
 #ifdef _GIZA_HAS_OSXCOCOA
     case GIZA_DEVICE_OSXCOCOA:
+      _giza_init_band (mode);
       _giza_get_key_press_osxcocoa (mode, moveCurs, nanc, xanch, yanch, x, y, ch);
-    return 0;
+      _giza_destroy_band (mode);
+      return 0;
 #endif
 
 

--- a/test/C/Makefile.am
+++ b/test/C/Makefile.am
@@ -22,7 +22,8 @@ interactive_ctests = test-arrow test-box test-cairo-xw test-change-page \
 	test-error-bars test-giza-xw test-line-cap \
 	test-line-style test-openclose test-points \
 	test-qtext test-rectangle test-set-line-width \
-	test-vector test-window test-XOpenDisplay test-contour test-render
+	test-vector test-window test-XOpenDisplay test-contour test-render \
+	test-band
 
 TESTS = $(auto_ctests)
 check_PROGRAMS = $(auto_ctests) $(interactive_ctests)


### PR DESCRIPTION
This PR implements the missing band (rubber-band cursor) functionality for the /osx driver, as noted in the review of PR #86.

- GizaBandView: transparent NSView overlay drawing band shapes via CoreGraphics modes 1-8 (line, rect, horzlines, vertlines, horzline, vertline, crosshair, circle)
- waitForInputEventWithBand: mouse-moved events update band while waiting for click
- _giza_init_band_osxcocoa: provide dummy cairo context for Band.box/restore
- _giza_osxcocoa_wait_for_event_band: attach+wait+detach on main thread via _run_on_main to avoid deadlock with dispatch mechanism
- giza-drivers.c: call _giza_init_band/_giza_destroy_band for OSXCOCOA device
- test/C/Makefile.am: add test-band to interactive_ctests