### PR TITLE
Fix osx issues

### DIFF
--- a/src/giza-driver-osxcocoa-bridge.c
+++ b/src/giza-driver-osxcocoa-bridge.c
@@ -62,6 +62,14 @@
 /* Internal: create cairo-quartz surface from CGContext                      */
 /* ======================================================================== */
 
+/* Plot area (Dev[id].width/height) plus margins — matches XW[id].width/height */
+static void
+_osxcocoa_surface_size (int *wwin, int *hwin)
+{
+    *wwin = Dev[id].width  + 2 * GIZA_OSXCOCOA_MARGIN;
+    *hwin = Dev[id].height + 2 * GIZA_OSXCOCOA_MARGIN;
+}
+
 static int
 _osxcocoa_create_surface (GizaCGContextRef cgctx, int width, int height)
 {
@@ -84,17 +92,22 @@ _osxcocoa_create_surface (GizaCGContextRef cgctx, int width, int height)
 int
 _giza_open_device_osxcocoa (double width, double height, int units)
 {
-    int wpx, hpx;
-    if (width > 1.0 && height > 1.0)
-        _giza_get_specified_size(width, height, units, &wpx, &hpx);
+    int wwin, hwin;
+
+    Dev[id].deviceUnitsPermm    = GIZA_OSXCOCOA_UNITS_PER_MM;
+    Dev[id].deviceUnitsPerPixel = GIZA_OSXCOCOA_UNITS_PER_PIXEL;
+    Dev[id].isInteractive       = 1;
+    Dev[id].defaultBackgroundAlpha = 1.0;
+
+    /* Match /xw: Dev[id].width/height is the plot area; surface adds margins */
+    if (width > 0. && height > 0. && units > 0)
+        _giza_get_specified_size(width, height, units, &Dev[id].width, &Dev[id].height);
     else {
-        wpx = GIZA_OSXCOCOA_DEFAULT_WIDTH;
-        hpx = GIZA_OSXCOCOA_DEFAULT_HEIGHT;
+        Dev[id].width  = GIZA_OSXCOCOA_DEFAULT_WIDTH;
+        Dev[id].height = GIZA_OSXCOCOA_DEFAULT_HEIGHT;
     }
 
-    /* total window size includes margin */
-    int wwin = wpx + 2 * GIZA_OSXCOCOA_MARGIN;
-    int hwin = hpx + 2 * GIZA_OSXCOCOA_MARGIN;
+    _osxcocoa_surface_size(&wwin, &hwin);
 
     _giza_osxcocoa_start_app_if_needed();
 
@@ -108,14 +121,6 @@ _giza_open_device_osxcocoa (double width, double height, int units)
         _giza_osxcocoa_close_window(id);
         return 1;
     }
-
-
-    Dev[id].width               = wwin;
-    Dev[id].height              = hwin;
-    Dev[id].deviceUnitsPermm    = GIZA_OSXCOCOA_UNITS_PER_MM;
-    Dev[id].deviceUnitsPerPixel = GIZA_OSXCOCOA_UNITS_PER_PIXEL;
-    Dev[id].isInteractive       = 1;
-    Dev[id].defaultBackgroundAlpha = 1.0;
 
     return 0;
 }
@@ -139,8 +144,14 @@ _giza_flush_device_osxcocoa (void)
 void
 _giza_change_page_osxcocoa (void)
 {
-    int wwin = Dev[id].width;
-    int hwin = Dev[id].height;
+    int wwin, hwin;
+
+    if (Dev[id].resize)
+        _giza_osxcocoa_resize_window(id,
+                                   Dev[id].width  + 2 * GIZA_OSXCOCOA_MARGIN,
+                                   Dev[id].height + 2 * GIZA_OSXCOCOA_MARGIN);
+
+    _osxcocoa_surface_size(&wwin, &hwin);
 
     /* destroy old cairo objects */
     if (Dev[id].context) {
@@ -176,11 +187,12 @@ _giza_close_device_osxcocoa (void)
 void
 _giza_init_norm_osxcocoa (void)
 {
+    /* Same layout as _giza_init_norm_xw: norm coords map to the plot area */
     cairo_matrix_init(&(Dev[id].Win.normCoords),
-                      (double)  Dev[id].width,  0.0,
+                      (double) Dev[id].width, 0.0,
                       0.0, (double) -Dev[id].height,
-                      (double)  GIZA_OSXCOCOA_MARGIN,
-                      (double) (Dev[id].height - GIZA_OSXCOCOA_MARGIN));
+                      (double) GIZA_OSXCOCOA_MARGIN,
+                      (double) (Dev[id].height + GIZA_OSXCOCOA_MARGIN));
     _giza_set_trans(GIZA_TRANS_NORM);
 }
 
@@ -189,9 +201,12 @@ _giza_init_norm_osxcocoa (void)
 void
 _giza_expand_clipping_osxcocoa (void)
 {
+    int wwin, hwin;
+
+    _osxcocoa_surface_size(&wwin, &hwin);
     _giza_set_trans(GIZA_TRANS_IDEN);
     cairo_reset_clip(Dev[id].context);
-    cairo_rectangle(Dev[id].context, 0, 0, Dev[id].width, Dev[id].height);
+    cairo_rectangle(Dev[id].context, 0, 0, wwin, hwin);
     cairo_clip(Dev[id].context);
 }
 
@@ -206,14 +221,10 @@ _giza_get_key_press_osxcocoa (int mode, int moveCurs,
     int oldTrans = _giza_get_trans();
     _giza_set_trans(GIZA_TRANS_WORLD);
 
-    /* Convert anchor world coords → device (surface) coords for the band overlay */
-    double axd = xanc[0], ayd = yanc[0];
-    cairo_user_to_device(Dev[id].context, &axd, &ayd);
-
     float fx, fy;
-    /* attach + wait + detach をmainスレッドで一括処理してデッドロック回避 */
+    /* attach + wait + detach on main thread to avoid deadlock */
     if (mode > 0) {
-        /* Convert anchor world coords → device (surface) coords for the band overlay */
+        /* Convert anchor world coords to device (surface) coords for band overlay */
         double axd = xanc[0], ayd = yanc[0];
         cairo_user_to_device(Dev[id].context, &axd, &ayd);
         _giza_osxcocoa_wait_for_event_band(id, mode, (float)axd, (float)ayd, &fx, &fy, ch);
@@ -237,8 +248,10 @@ _giza_init_band_osxcocoa (void)
      * Instead GizaBandView draws directly via CoreGraphics.
      * However _giza_init_band() in giza-drivers.c will try to use Band.box
      * after calling us, so we must provide a valid (dummy) cairo context. */
-    int w = Dev[id].width  > 0 ? Dev[id].width  : 1;
-    int h = Dev[id].height > 0 ? Dev[id].height : 1;
+    int wwin, hwin;
+    _osxcocoa_surface_size(&wwin, &hwin);
+    int w = wwin > 0 ? wwin : 1;
+    int h = hwin > 0 ? hwin : 1;
     cairo_surface_t *dummy = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, w, h);
     if (cairo_surface_status(dummy) != CAIRO_STATUS_SUCCESS) return 0;
     Band.onscreen = dummy;

--- a/src/giza-driver-osxcocoa-bridge.c
+++ b/src/giza-driver-osxcocoa-bridge.c
@@ -59,10 +59,12 @@
 #define GIZA_OSXCOCOA_MARGIN          20
 
 /* ======================================================================== */
-/* Internal: create cairo-quartz surface from CGContext                      */
+/* Internal: cairo image surface helpers                                   */
 /* ======================================================================== */
 
-/* Plot area (Dev[id].width/height) plus margins — matches XW[id].width/height */
+/**
+ * Full window size (plot area plus margins), matching XW[id].width/height.
+ */
 static void
 _osxcocoa_surface_size (int *wwin, int *hwin)
 {
@@ -70,6 +72,11 @@ _osxcocoa_surface_size (int *wwin, int *hwin)
     *hwin = Dev[id].height + 2 * GIZA_OSXCOCOA_MARGIN;
 }
 
+/**
+ * Allocate a new cairo image surface for the plot buffer.
+ *
+ * Return value: 0 on success, 1 on failure.
+ */
 static int
 _osxcocoa_create_surface (GizaCGContextRef cgctx, int width, int height)
 {
@@ -83,6 +90,79 @@ _osxcocoa_create_surface (GizaCGContextRef cgctx, int width, int height)
         return 1;
     }
     return 0;
+}
+
+/**
+ * If the user resized the NSWindow, update Dev[id] plot size to match /xw.
+ *
+ * Return value: 1 if Dev[id] was updated, 0 if already in sync.
+ */
+static int
+_osxcocoa_sync_device_to_view (void)
+{
+    int viewW, viewH;
+    int surfW = 0, surfH = 0;
+
+    _giza_osxcocoa_get_view_size(id, &viewW, &viewH);
+    if (viewW <= 0 || viewH <= 0)
+        return 0;
+
+    /* Compare NSWindow size to the cairo buffer (full window incl. margins) */
+    if (Dev[id].surface) {
+        surfW = cairo_image_surface_get_width(Dev[id].surface);
+        surfH = cairo_image_surface_get_height(Dev[id].surface);
+    } else {
+        _osxcocoa_surface_size(&surfW, &surfH);
+    }
+
+    if (viewW == surfW && viewH == surfH)
+        return 0;
+
+    Dev[id].width  = viewW;
+    Dev[id].height = viewH;
+    /* take care of margin - if there's room for that */
+    if (Dev[id].width > 2 * GIZA_OSXCOCOA_MARGIN)
+        Dev[id].width -= 2 * GIZA_OSXCOCOA_MARGIN;
+    if (Dev[id].height > 2 * GIZA_OSXCOCOA_MARGIN)
+        Dev[id].height -= 2 * GIZA_OSXCOCOA_MARGIN;
+    if (Dev[id].width < 1)
+        Dev[id].width = 1;
+    if (Dev[id].height < 1)
+        Dev[id].height = 1;
+
+    /* adjust panel size for resized surface */
+    _giza_init_norm_osxcocoa();
+    Dev[id].panelwidth  = Dev[id].width  / Dev[id].nx;
+    Dev[id].panelheight = Dev[id].height / Dev[id].ny;
+    return 1;
+}
+
+/**
+ * Destroy and recreate the cairo image surface at the current plot size.
+ */
+static void
+_osxcocoa_recreate_surface (void)
+{
+    int wwin, hwin;
+
+    _osxcocoa_surface_size(&wwin, &hwin);
+
+    /* destroy old cairo objects */
+    if (Dev[id].context) {
+        cairo_destroy(Dev[id].context);
+        Dev[id].context = NULL;
+    }
+    if (Dev[id].surface) {
+        cairo_surface_finish(Dev[id].surface);
+        cairo_surface_destroy(Dev[id].surface);
+        Dev[id].surface = NULL;
+    }
+
+    /* clear backing layer and get new CGContext */
+    GizaCGContextRef cgctx = _giza_osxcocoa_clear_and_get_context(id, wwin, hwin);
+    if (!cgctx) return;
+    if (_osxcocoa_create_surface(cgctx, wwin, hwin) != 0) return;
+    Dev[id].context = cairo_create(Dev[id].surface);
 }
 
 /* ======================================================================== */
@@ -127,6 +207,21 @@ _giza_open_device_osxcocoa (double width, double height, int units)
 
 /* ---------------------------------------------------------------------- */
 
+/**
+ * Sync NSWindow size to Dev[id] and recreate the cairo surface if needed.
+ *
+ * Called via _giza_prepare_interactive_draw from giza_get_paper_size and
+ * giza_set_viewport (before splash queries aspect ratio in setpage2).
+ */
+void
+_giza_osxcocoa_prepare_draw (void)
+{
+    if (_osxcocoa_sync_device_to_view())
+        _osxcocoa_recreate_surface();
+}
+
+/* ---------------------------------------------------------------------- */
+
 void
 _giza_flush_device_osxcocoa (void)
 {
@@ -144,32 +239,16 @@ _giza_flush_device_osxcocoa (void)
 void
 _giza_change_page_osxcocoa (void)
 {
-    int wwin, hwin;
-
     if (Dev[id].resize)
         _giza_osxcocoa_resize_window(id,
                                    Dev[id].width  + 2 * GIZA_OSXCOCOA_MARGIN,
                                    Dev[id].height + 2 * GIZA_OSXCOCOA_MARGIN);
+    else
+        /* user may have resized the NSWindow behind our backs */
+        _osxcocoa_sync_device_to_view();
 
-    _osxcocoa_surface_size(&wwin, &hwin);
-
-    /* destroy old cairo objects */
-    if (Dev[id].context) {
-        cairo_destroy(Dev[id].context);
-        Dev[id].context = NULL;
-    }
-    if (Dev[id].surface) {
-        cairo_surface_finish(Dev[id].surface);
-        cairo_surface_destroy(Dev[id].surface);
-        Dev[id].surface = NULL;
-    }
-
-    /* clear backing layer and get new CGContext */
-    GizaCGContextRef cgctx = _giza_osxcocoa_clear_and_get_context(id, wwin, hwin);
-    if (!cgctx) return;
-
-    if (_osxcocoa_create_surface(cgctx, wwin, hwin) != 0) return;
-    Dev[id].context = cairo_create(Dev[id].surface);
+    /* new page means new cairo surface (like /xw pixmap recreation) */
+    _osxcocoa_recreate_surface();
 }
 
 /* ---------------------------------------------------------------------- */
@@ -218,6 +297,9 @@ _giza_get_key_press_osxcocoa (int mode, int moveCurs,
                           const double *xanc, const double *yanc,
                           double *x, double *y, char *ch)
 {
+    (void) moveCurs;
+    (void) nanc;
+
     int oldTrans = _giza_get_trans();
     _giza_set_trans(GIZA_TRANS_WORLD);
 
@@ -260,20 +342,6 @@ _giza_init_band_osxcocoa (void)
     Band.maxWidth  = w;
     Band.maxHeight = h;
     return 1; /* success */
-}
-
-/* ---------------------------------------------------------------------- */
-
-/*
- * _giza_osxcocoa_handle_resize — 表示スケーリング方式では surface を再生成しない。
- * setFrameSize: は drawRect でのスケーリングに任せる。
- * この関数は参照が残っている場合のために stub として保持。
- */
-void
-_giza_osxcocoa_handle_resize (int devId, int width, int height)
-{
-    (void)devId; (void)width; (void)height;
-    /* no-op: display scaling is handled in GizaView -drawRect: */
 }
 
 #endif /* _GIZA_HAS_OSXCOCOA */

--- a/src/giza-driver-osxcocoa-bridge.c
+++ b/src/giza-driver-osxcocoa-bridge.c
@@ -115,16 +115,18 @@ _osxcocoa_sync_device_to_view (void)
         _osxcocoa_surface_size(&surfW, &surfH);
     }
 
-    if (viewW == surfW && viewH == surfH)
-        return 0;
+    /* minimum surface fits plot area (1px) plus both margins */
+    {
+        int minSurf = 2 * GIZA_OSXCOCOA_MARGIN + 1;
+        int expectedSurfW = viewW < minSurf ? minSurf : viewW;
+        int expectedSurfH = viewH < minSurf ? minSurf : viewH;
 
-    Dev[id].width  = viewW;
-    Dev[id].height = viewH;
-    /* take care of margin - if there's room for that */
-    if (Dev[id].width > 2 * GIZA_OSXCOCOA_MARGIN)
-        Dev[id].width -= 2 * GIZA_OSXCOCOA_MARGIN;
-    if (Dev[id].height > 2 * GIZA_OSXCOCOA_MARGIN)
-        Dev[id].height -= 2 * GIZA_OSXCOCOA_MARGIN;
+        if (surfW == expectedSurfW && surfH == expectedSurfH)
+            return 0;
+    }
+
+    Dev[id].width  = viewW - 2 * GIZA_OSXCOCOA_MARGIN;
+    Dev[id].height = viewH - 2 * GIZA_OSXCOCOA_MARGIN;
     if (Dev[id].width < 1)
         Dev[id].width = 1;
     if (Dev[id].height < 1)
@@ -144,25 +146,44 @@ static void
 _osxcocoa_recreate_surface (void)
 {
     int wwin, hwin;
+    cairo_surface_t *old_surf = Dev[id].surface;
+    cairo_t         *old_ctx  = Dev[id].context;
 
     _osxcocoa_surface_size(&wwin, &hwin);
 
-    /* destroy old cairo objects */
-    if (Dev[id].context) {
-        cairo_destroy(Dev[id].context);
-        Dev[id].context = NULL;
-    }
-    if (Dev[id].surface) {
-        cairo_surface_finish(Dev[id].surface);
-        cairo_surface_destroy(Dev[id].surface);
-        Dev[id].surface = NULL;
-    }
-
-    /* clear backing layer and get new CGContext */
+    /* resize backing layer first; keep old cairo objects if this fails */
     GizaCGContextRef cgctx = _giza_osxcocoa_clear_and_get_context(id, wwin, hwin);
     if (!cgctx) return;
-    if (_osxcocoa_create_surface(cgctx, wwin, hwin) != 0) return;
-    Dev[id].context = cairo_create(Dev[id].surface);
+
+    cairo_surface_t *new_surf = cairo_image_surface_create(CAIRO_FORMAT_ARGB32,
+                                                           wwin, hwin);
+    if (!new_surf ||
+        cairo_surface_status(new_surf) != CAIRO_STATUS_SUCCESS) {
+        _giza_error("giza-driver-osxcocoa", "could not create cairo image surface");
+        if (new_surf)
+            cairo_surface_destroy(new_surf);
+        return;
+    }
+
+    cairo_t *new_ctx = cairo_create(new_surf);
+    if (!new_ctx || cairo_status(new_ctx) != CAIRO_STATUS_SUCCESS) {
+        _giza_error("giza-driver-osxcocoa", "could not create cairo context");
+        if (new_ctx)
+            cairo_destroy(new_ctx);
+        cairo_surface_destroy(new_surf);
+        return;
+    }
+
+    /* destroy old cairo objects */
+    if (old_ctx)
+        cairo_destroy(old_ctx);
+    if (old_surf) {
+        cairo_surface_finish(old_surf);
+        cairo_surface_destroy(old_surf);
+    }
+
+    Dev[id].surface = new_surf;
+    Dev[id].context = new_ctx;
 }
 
 /* ======================================================================== */

--- a/src/giza-driver-osxcocoa-private.h
+++ b/src/giza-driver-osxcocoa-private.h
@@ -39,6 +39,7 @@ void _giza_change_page_osxcocoa     (void);
 void _giza_close_device_osxcocoa    (void);
 void _giza_init_norm_osxcocoa       (void);
 void _giza_expand_clipping_osxcocoa (void);
+void _giza_osxcocoa_prepare_draw       (void);
 void _giza_get_key_press_osxcocoa   (int mode, int moveCurs,
                                  int nanc,
                                  const double *xanc, const double *yanc,
@@ -49,23 +50,19 @@ int  _giza_init_band_osxcocoa       (void);
 void         _giza_osxcocoa_start_app_if_needed (void);
 void         _giza_osxcocoa_mark_app_ready       (void);
 GizaCGContextRef _giza_osxcocoa_open_window          (int devId, int width, int height);
-void         _giza_osxcocoa_flush               (int devId);
 void         _giza_osxcocoa_flush_pixels         (int devId,
                                              unsigned char *data,
                                              int width, int height,
                                              int stride);
 GizaCGContextRef _giza_osxcocoa_clear_and_get_context(int devId, int width, int height);
 void         _giza_osxcocoa_resize_window        (int devId, int width, int height);
+void         _giza_osxcocoa_get_view_size        (int devId, int *width, int *height);
 void         _giza_osxcocoa_close_window         (int devId);
 void         _giza_osxcocoa_wait_for_event       (int devId,
                                              float *x, float *y, char *ch);
 void         _giza_osxcocoa_wait_for_event_band  (int devId, int mode,
                                              float xancSurface, float yancSurface,
                                              float *x, float *y, char *ch);
-
-/* ---- resize callback (implemented in giza-driver-osxcocoa-bridge.c) ---------- */
-/* Called by GizaView -setFrameSize: */
-void _giza_osxcocoa_handle_resize (int devId, int width, int height);
 
 #endif /* __APPLE__ */
 #endif /* GIZA_DRIVER_OSXCOCOA_PRIVATE_H */

--- a/src/giza-driver-osxcocoa-private.h
+++ b/src/giza-driver-osxcocoa-private.h
@@ -55,6 +55,7 @@ void         _giza_osxcocoa_flush_pixels         (int devId,
                                              int width, int height,
                                              int stride);
 GizaCGContextRef _giza_osxcocoa_clear_and_get_context(int devId, int width, int height);
+void         _giza_osxcocoa_resize_window        (int devId, int width, int height);
 void         _giza_osxcocoa_close_window         (int devId);
 void         _giza_osxcocoa_wait_for_event       (int devId,
                                              float *x, float *y, char *ch);

--- a/src/giza-driver-osxcocoa.m
+++ b/src/giza-driver-osxcocoa.m
@@ -459,7 +459,8 @@
 {
     NSSize bs = self.bounds.size;
     /* _displayRect が未計算なら view サイズから等倍で変換 */
-    if (_pixelWidth <= 0 || _pixelHeight <= 0 || _displayRect.size.width < 1) {
+    if (_pixelWidth <= 0 || _pixelHeight <= 0
+        || _displayRect.size.width < 1 || _displayRect.size.height < 1) {
         if (bs.width > 0 && bs.height > 0) {
             CGFloat sx = vp.x / bs.width  * (_pixelWidth  > 0 ? _pixelWidth  : bs.width);
             CGFloat sy = (bs.height - vp.y) / bs.height
@@ -600,7 +601,7 @@ _giza_osxcocoa_open_window(int devId, int width, int height)
 CGContextRef
 _giza_osxcocoa_clear_and_get_context(int devId, int width, int height)
 {
-    if (!_osxcocoa_inuse[devId]) return NULL;
+    if (devId < 0 || devId >= GIZA_MAX_DEV || !_osxcocoa_inuse[devId]) return NULL;
     __block CGContextRef result = NULL;
     _run_on_main(^{
         GizaView *view = _osxcocoa_view[devId];
@@ -623,7 +624,7 @@ _giza_osxcocoa_clear_and_get_context(int devId, int width, int height)
 void
 _giza_osxcocoa_resize_window(int devId, int width, int height)
 {
-    if (!_osxcocoa_inuse[devId]) return;
+    if (devId < 0 || devId >= GIZA_MAX_DEV || !_osxcocoa_inuse[devId]) return;
     _run_on_main(^{
         NSWindow *win = _osxcocoa_win[devId];
         GizaView *view = _osxcocoa_view[devId];

--- a/src/giza-driver-osxcocoa.m
+++ b/src/giza-driver-osxcocoa.m
@@ -336,8 +336,7 @@
 - (void)setFrameSize:(NSSize)sz
 {
     [super setFrameSize:sz];
-    /* surface サイズは変えない。drawRect でスケーリングするだけ。
-     * _displayRect は drawRect 内で再計算されるので更新不要。 */
+    /* Cairo surface sync happens on replot via _giza_prepare_interactive_draw */
     [self setNeedsDisplay:YES];
 }
 
@@ -598,18 +597,6 @@ _giza_osxcocoa_open_window(int devId, int width, int height)
     return result;
 }
 
-void
-_giza_osxcocoa_flush(int devId)
-{
-    if (!_osxcocoa_inuse[devId]) return;
-    _run_on_main(^{
-        GizaView *view = _osxcocoa_view[devId];
-        [view setNeedsDisplay:YES];
-        [view displayIfNeeded];
-        if (!_app_on_main) _drain_events();
-    });
-}
-
 CGContextRef
 _giza_osxcocoa_clear_and_get_context(int devId, int width, int height)
 {
@@ -626,6 +613,13 @@ _giza_osxcocoa_clear_and_get_context(int devId, int width, int height)
     return result;
 }
 
+/* ======================================================================== */
+/* _giza_osxcocoa_resize_window                                              */
+/* ======================================================================== */
+
+/**
+ * Resize the NSWindow and GizaView to the given pixel dimensions.
+ */
 void
 _giza_osxcocoa_resize_window(int devId, int width, int height)
 {
@@ -638,6 +632,33 @@ _giza_osxcocoa_resize_window(int devId, int width, int height)
         [view rebuildLayerSize:NSMakeSize(width, height)];
         [view setNeedsDisplay:YES];
     });
+}
+
+/* ======================================================================== */
+/* _giza_osxcocoa_get_view_size                                              */
+/* ======================================================================== */
+
+/**
+ * Return the current GizaView size in pixels (main-thread safe).
+ */
+void
+_giza_osxcocoa_get_view_size(int devId, int *width, int *height)
+{
+    if (width)  *width  = 0;
+    if (height) *height = 0;
+    if (!width || !height) return;
+    if (devId < 0 || devId >= GIZA_MAX_DEV || !_osxcocoa_inuse[devId]) return;
+
+    __block int w = 0, h = 0;
+    _run_on_main(^{
+        GizaView *view = _osxcocoa_view[devId];
+        if (!view) return;
+        NSSize sz = [view bounds].size;
+        w = (int)(sz.width  + 0.5);
+        h = (int)(sz.height + 0.5);
+    });
+    *width  = w;
+    *height = h;
 }
 
 void

--- a/src/giza-driver-osxcocoa.m
+++ b/src/giza-driver-osxcocoa.m
@@ -116,13 +116,15 @@
 - (BOOL)isOpaque { return NO; }
 - (BOOL)acceptsFirstResponder { return NO; }  /* events handled by GizaView */
 
-/* Convert a surface-space point to view-space for drawing */
+/* Convert cairo surface coords to view coords for drawing.
+ * GizaView is not flipped (AppKit origin bottom-left, y up); cairo uses y down. */
 - (CGPoint)_viewPtFromSurface:(NSPoint)sp
 {
     if (_surfW <= 0 || _surfH <= 0 || _displayRect.size.width < 1)
         return CGPointMake(sp.x, sp.y);
     CGFloat sx = _displayRect.origin.x + sp.x / _surfW * _displayRect.size.width;
-    CGFloat sy = _displayRect.origin.y + sp.y / _surfH * _displayRect.size.height;
+    CGFloat sy = _displayRect.origin.y + _displayRect.size.height
+               - (sp.y / _surfH * _displayRect.size.height);
     return CGPointMake(sx, sy);
 }
 
@@ -249,6 +251,7 @@
 - (void)setPixelData:(unsigned char*)data width:(int)w height:(int)h stride:(int)s;
 /* view 座標 → cairo surface 座標への逆変換 */
 - (NSPoint)surfacePointFromViewPoint:(NSPoint)vp;
+- (NSPoint)currentMouseViewPoint;
 /* band control */
 - (void)attachBandViewMode:(int)mode anchorSurfacePt:(NSPoint)anc;
 - (void)detachBandView;
@@ -351,8 +354,18 @@
         case 27:                      _eventCh='q'; break;
         default: _eventCh=(char)(c&0x7F);
     }
-    _eventPt = NSMakePoint(self.bounds.size.width/2,self.bounds.size.height/2);
+    /* Return cursor position at key press, not the view centre (matches /xw). */
+    _eventPt = [self surfacePointFromViewPoint:[self currentMouseViewPoint]];
     _gotEvent = YES;
+}
+
+/* Mouse position in this view's coordinate system */
+- (NSPoint)currentMouseViewPoint
+{
+    NSWindow *win = [self window];
+    if (win)
+        return [self convertPoint:[win mouseLocationOutsideOfEventStream] fromView:nil];
+    return NSMakePoint(self.bounds.size.width / 2, self.bounds.size.height / 2);
 }
 
 - (void)_recordButton:(NSEvent *)ev ch:(char)ch {
@@ -379,6 +392,7 @@
 
 - (void)waitForInputEvent {
     _gotEvent = NO;
+    [[self window] setAcceptsMouseMovedEvents:YES];
     while (!_gotEvent) {
         NSEvent *ev = [NSApp nextEventMatchingMask:NSEventMaskAny
                                          untilDate:[NSDate distantFuture]
@@ -386,6 +400,7 @@
                                            dequeue:YES];
         if (ev) [NSApp sendEvent:ev];
     }
+    [[self window] setAcceptsMouseMovedEvents:NO];
 }
 
 /* Band-aware event loop: also handles mouse-moved events to update band */
@@ -443,12 +458,21 @@
 
 - (NSPoint)surfacePointFromViewPoint:(NSPoint)vp
 {
-    /* _displayRect が未計算なら等倍で返す */
-    if (_pixelWidth <= 0 || _pixelHeight <= 0 || _displayRect.size.width < 1)
-        return vp;
-    /* view 座標 → surface 座標 */
+    NSSize bs = self.bounds.size;
+    /* _displayRect が未計算なら view サイズから等倍で変換 */
+    if (_pixelWidth <= 0 || _pixelHeight <= 0 || _displayRect.size.width < 1) {
+        if (bs.width > 0 && bs.height > 0) {
+            CGFloat sx = vp.x / bs.width  * (_pixelWidth  > 0 ? _pixelWidth  : bs.width);
+            CGFloat sy = (bs.height - vp.y) / bs.height
+                     * (_pixelHeight > 0 ? _pixelHeight : bs.height);
+            return NSMakePoint(sx, sy);
+        }
+        return NSMakePoint(vp.x, bs.height - vp.y);
+    }
+    /* view 座標 (y up) → cairo surface 座標 (y down) */
     CGFloat sx = (vp.x - _displayRect.origin.x) / _displayRect.size.width  * _pixelWidth;
-    CGFloat sy = (vp.y - _displayRect.origin.y) / _displayRect.size.height * _pixelHeight;
+    CGFloat sy = (_displayRect.origin.y + _displayRect.size.height - vp.y)
+               / _displayRect.size.height * _pixelHeight;
     return NSMakePoint(sx, sy);
 }
 

--- a/src/giza-driver-osxcocoa.m
+++ b/src/giza-driver-osxcocoa.m
@@ -593,12 +593,27 @@ _giza_osxcocoa_clear_and_get_context(int devId, int width, int height)
     __block CGContextRef result = NULL;
     _run_on_main(^{
         GizaView *view = _osxcocoa_view[devId];
+        [view setFrameSize:NSMakeSize(width, height)];
         [view rebuildLayerSize:NSMakeSize(width,height)];
         [view setNeedsDisplay:YES];
         CGLayerRef layer = [view cgLayer];
         result = layer ? CGLayerGetContext(layer) : NULL;
     });
     return result;
+}
+
+void
+_giza_osxcocoa_resize_window(int devId, int width, int height)
+{
+    if (!_osxcocoa_inuse[devId]) return;
+    _run_on_main(^{
+        NSWindow *win = _osxcocoa_win[devId];
+        GizaView *view = _osxcocoa_view[devId];
+        [win setContentSize:NSMakeSize(width, height)];
+        [view setFrameSize:NSMakeSize(width, height)];
+        [view rebuildLayerSize:NSMakeSize(width, height)];
+        [view setNeedsDisplay:YES];
+    });
 }
 
 void

--- a/src/giza-driver-xw-private.h
+++ b/src/giza-driver-xw-private.h
@@ -35,5 +35,6 @@ void _giza_get_key_press_xw (int mode, int moveCurs, int nanc, const double *xan
                              double *x, double *y, char *ch);
 int _giza_init_band_xw (void);
 int _giza_select_xw(int devid);
+void _giza_prepare_draw_xw (void);
 
 #endif

--- a/src/giza-driver-xw.c
+++ b/src/giza-driver-xw.c
@@ -253,6 +253,100 @@ _giza_flush_device_xw (void)
 }
 
 /**
+ * Query the current X window outer size in pixels.
+ */
+static void
+_xw_query_window_size (unsigned int *wwin, unsigned int *hwin)
+{
+  int          x_return, y_return;
+  Window       root_return;
+  unsigned int border_width_return, depth_return;
+
+  XGetGeometry (XW[id].display, XW[id].window, &root_return,
+                &x_return, &y_return, wwin, hwin,
+                &border_width_return, &depth_return);
+}
+
+/**
+ * Update Dev[id] plot area from full window dimensions (margins excluded).
+ */
+static void
+_xw_sync_device_to_window (unsigned int wwin, unsigned int hwin)
+{
+  XW[id].width  = wwin;
+  XW[id].height = hwin;
+  Dev[id].width  = (int) wwin;
+  Dev[id].height = (int) hwin;
+  /* take care of margin - if there's room for that */
+  if (Dev[id].width > 2 * GIZA_XW_MARGIN)
+    Dev[id].width -= 2 * GIZA_XW_MARGIN;
+  if (Dev[id].height > 2 * GIZA_XW_MARGIN)
+    Dev[id].height -= 2 * GIZA_XW_MARGIN;
+  if (Dev[id].width < 1)
+    Dev[id].width = 1;
+  if (Dev[id].height < 1)
+    Dev[id].height = 1;
+
+  /* adjust panel size for resized surface */
+  _giza_init_norm_xw ();
+  Dev[id].panelwidth  = Dev[id].width  / Dev[id].nx;
+  Dev[id].panelheight = Dev[id].height / Dev[id].ny;
+}
+
+/**
+ * Destroy and recreate the X pixmap and cairo surface at the current size.
+ */
+static void
+_xw_recreate_surface (void)
+{
+  if (!Dev[id].surface)
+    return;
+
+  /* This function is called for each new page, so new page means new pixmap */
+  cairo_destroy (Dev[id].context);
+  cairo_surface_finish (Dev[id].surface);
+  cairo_status_t status = cairo_surface_status (Dev[id].surface);
+  if (status != CAIRO_STATUS_SUCCESS)
+    _giza_error ("_xw_recreate_surface", cairo_status_to_string (status));
+
+  cairo_surface_destroy (Dev[id].surface);
+  XFreePixmap (XW[id].display, XW[id].pixmap);
+
+  /* New page means new pixmap */
+  XW[id].pixmap = XCreatePixmap (XW[id].display, XW[id].window,
+                                 (unsigned) XW[id].width,
+                                 (unsigned) XW[id].height,
+                                 (unsigned) XW[id].depth);
+  /* New pixmap means new cairo surface */
+  Dev[id].surface = cairo_xlib_surface_create (XW[id].display, XW[id].pixmap,
+                                               XW[id].visual,
+                                               XW[id].width, XW[id].height);
+  Dev[id].context = cairo_create (Dev[id].surface);
+}
+
+/**
+ * Sync X window size to Dev[id] and recreate the cairo surface if needed.
+ *
+ * Called via _giza_prepare_interactive_draw before paper-size queries and
+ * viewport setup (e.g. after the user resizes the window interactively).
+ */
+void
+_giza_prepare_draw_xw (void)
+{
+  unsigned int width_return, height_return;
+
+  _xw_query_window_size (&width_return, &height_return);
+
+  /* already in sync — nothing to do */
+  if ((unsigned int) XW[id].width == width_return
+      && (unsigned int) XW[id].height == height_return)
+    return;
+
+  _xw_sync_device_to_window (width_return, height_return);
+  _xw_recreate_surface ();
+}
+
+/**
  * Advances the X window device to the next page.
  * If resize was set upon function entry, resize the window accordingly.
  * If, otoh, we detect the window was resized, take appropriate action and
@@ -261,12 +355,10 @@ _giza_flush_device_xw (void)
 void
 _giza_change_page_xw (void)
 {
-  int          x_return, y_return;
-  Window       root_return;
-  unsigned int width_return, height_return, border_width_return, depth_return;
+  unsigned int width_return, height_return;
 
   /* Enquire current geometry to see if it's changed */
-  XGetGeometry(XW[id].display, XW[id].window, &root_return, &x_return, &y_return, &width_return, &height_return, &border_width_return, &depth_return);
+  _xw_query_window_size (&width_return, &height_return);
   /* interactive logging feature */
   if (Sets.autolog && Dev[id].drawn) _giza_write_log_file(Dev[id].surface);
 
@@ -279,36 +371,10 @@ _giza_change_page_xw (void)
      XResizeWindow(XW[id].display, XW[id].window, (unsigned) XW[id].width, (unsigned) XW[id].height);
   } else if( (unsigned int)XW[id].width!=width_return || (unsigned int)XW[id].height!=height_return ) {
       /* Oh. Someone probably resized the XWindow behind our backs. Handle that here */
-      XW[id].width  = Dev[id].width  = width_return;
-      XW[id].height = Dev[id].height = height_return;
-
-      /* take care of margin - if there's room for that */
-      if( Dev[id].width > 2*GIZA_XW_MARGIN )
-          Dev[id].width -= 2*GIZA_XW_MARGIN;
-      if( Dev[id].height > 2*GIZA_XW_MARGIN )
-          Dev[id].height -= 2*GIZA_XW_MARGIN;
-      /* Do stuff needed to reflect changed window size, notably adjust panel size in case of resized surface*/
-      _giza_init_norm();
-      Dev[id].panelwidth  = Dev[id].width  / Dev[id].nx;
-      Dev[id].panelheight = Dev[id].height / Dev[id].ny;
+      _xw_sync_device_to_window (width_return, height_return);
   }
 
-  /* This function is called for each new page, so new page means new pixmap */
-  cairo_destroy(Dev[id].context);
-  cairo_surface_finish (Dev[id].surface);
-  cairo_status_t status = cairo_surface_status (Dev[id].surface);
-  if (status != CAIRO_STATUS_SUCCESS)
-     _giza_error("giza_change_page_xw",cairo_status_to_string(status));
-
-  cairo_surface_destroy (Dev[id].surface);
-  XFreePixmap (XW[id].display, XW[id].pixmap);
-
-  /* New page means new pixmap */
-  XW[id].pixmap = XCreatePixmap (XW[id].display, XW[id].window, (unsigned) XW[id].width, (unsigned) XW[id].height, (unsigned) XW[id].depth);
-
-  /* New pixmap means new cairo surface */
-  Dev[id].surface = cairo_xlib_surface_create (XW[id].display, XW[id].pixmap, XW[id].visual, XW[id].width, XW[id].height);
-  Dev[id].context = cairo_create (Dev[id].surface);
+  _xw_recreate_surface ();
 }
 
 /**

--- a/src/giza-driver-xw.c
+++ b/src/giza-driver-xw.c
@@ -275,13 +275,8 @@ _xw_sync_device_to_window (unsigned int wwin, unsigned int hwin)
 {
   XW[id].width  = wwin;
   XW[id].height = hwin;
-  Dev[id].width  = (int) wwin;
-  Dev[id].height = (int) hwin;
-  /* take care of margin - if there's room for that */
-  if (Dev[id].width > 2 * GIZA_XW_MARGIN)
-    Dev[id].width -= 2 * GIZA_XW_MARGIN;
-  if (Dev[id].height > 2 * GIZA_XW_MARGIN)
-    Dev[id].height -= 2 * GIZA_XW_MARGIN;
+  Dev[id].width  = (int) wwin - 2 * GIZA_XW_MARGIN;
+  Dev[id].height = (int) hwin - 2 * GIZA_XW_MARGIN;
   if (Dev[id].width < 1)
     Dev[id].width = 1;
   if (Dev[id].height < 1)
@@ -302,6 +297,30 @@ _xw_recreate_surface (void)
   if (!Dev[id].surface)
     return;
 
+  /* create new pixmap and cairo objects before destroying the old ones */
+  Pixmap new_pixmap = XCreatePixmap (XW[id].display, XW[id].window,
+                                     (unsigned) XW[id].width,
+                                     (unsigned) XW[id].height,
+                                     (unsigned) XW[id].depth);
+  cairo_surface_t *new_surf = cairo_xlib_surface_create (XW[id].display, new_pixmap,
+                                                         XW[id].visual,
+                                                         XW[id].width, XW[id].height);
+  if (!new_surf || cairo_surface_status (new_surf) != CAIRO_STATUS_SUCCESS) {
+    _giza_error ("_xw_recreate_surface", "could not create cairo xlib surface");
+    XFreePixmap (XW[id].display, new_pixmap);
+    return;
+  }
+
+  cairo_t *new_ctx = cairo_create (new_surf);
+  if (!new_ctx || cairo_status (new_ctx) != CAIRO_STATUS_SUCCESS) {
+    _giza_error ("_xw_recreate_surface", "could not create cairo context");
+    if (new_ctx)
+      cairo_destroy (new_ctx);
+    cairo_surface_destroy (new_surf);
+    XFreePixmap (XW[id].display, new_pixmap);
+    return;
+  }
+
   /* This function is called for each new page, so new page means new pixmap */
   cairo_destroy (Dev[id].context);
   cairo_surface_finish (Dev[id].surface);
@@ -312,16 +331,9 @@ _xw_recreate_surface (void)
   cairo_surface_destroy (Dev[id].surface);
   XFreePixmap (XW[id].display, XW[id].pixmap);
 
-  /* New page means new pixmap */
-  XW[id].pixmap = XCreatePixmap (XW[id].display, XW[id].window,
-                                 (unsigned) XW[id].width,
-                                 (unsigned) XW[id].height,
-                                 (unsigned) XW[id].depth);
-  /* New pixmap means new cairo surface */
-  Dev[id].surface = cairo_xlib_surface_create (XW[id].display, XW[id].pixmap,
-                                               XW[id].visual,
-                                               XW[id].width, XW[id].height);
-  Dev[id].context = cairo_create (Dev[id].surface);
+  XW[id].pixmap = new_pixmap;
+  Dev[id].surface = new_surf;
+  Dev[id].context = new_ctx;
 }
 
 /**

--- a/src/giza-drivers-private.h
+++ b/src/giza-drivers-private.h
@@ -53,4 +53,5 @@ void _giza_trim(char *str);
 void _giza_get_filename_for_device (char *filename, char *prefix, int pgNum, char *extension, int lastpage);
 void _giza_get_specified_size(double paperwidth, double paperheight, int paperunits, int *width, int *height);
 int _giza_complete_device_open (int draw_background);
+void _giza_prepare_interactive_draw (void);
 void _giza_init_all_devices_once (void);

--- a/src/giza-drivers.c
+++ b/src/giza-drivers.c
@@ -80,6 +80,36 @@ _giza_init_all_devices_once (void)
   didInit = 1;
 }
 
+/**
+ * Sync interactive window size with the cairo surface before drawing.
+ *
+ * Dispatches to the /xw or /osx driver when the user may have resized the
+ * window. Called from giza_get_paper_size and giza_set_viewport so paper-
+ * size queries (e.g. splash plot_qvsz in setpage2) see current dimensions.
+ */
+void
+_giza_prepare_interactive_draw (void)
+{
+  if (!Dev[id].deviceOpen || !Dev[id].isInteractive)
+    return;
+
+  switch (Dev[id].type)
+    {
+#ifdef _GIZA_HAS_XW
+    case GIZA_DEVICE_XW:
+      _giza_prepare_draw_xw ();
+      break;
+#endif
+#ifdef _GIZA_HAS_OSXCOCOA
+    case GIZA_DEVICE_OSXCOCOA:
+      _giza_osxcocoa_prepare_draw ();
+      break;
+#endif
+    default:
+      break;
+    }
+}
+
 /* global settings */
 giza_settings_t Sets;
 int id;

--- a/src/giza-paper.c
+++ b/src/giza-paper.c
@@ -146,6 +146,10 @@ giza_get_paper_size (int units, double *width, double *height)
       return;
     }
 
+  /* Interactive drivers sync window size here so paper-size queries (e.g.
+   * splash plot_qvsz in setpage2) see the current dimensions. */
+  _giza_prepare_interactive_draw ();
+
   switch(units)
      {
      case GIZA_UNITS_MM:

--- a/src/giza-viewport.c
+++ b/src/giza-viewport.c
@@ -52,6 +52,9 @@ giza_set_viewport (double xleft, double xright, double ybottom, double ytop)
   if (!_giza_check_device_open ("giza_set_viewport"))
     return;
 
+  /* sync interactive window size before viewport math (see giza_get_paper_size) */
+  _giza_prepare_interactive_draw ();
+
   if (_giza_equal(xleft,xright) || _giza_equal(ybottom,ytop))
     {
       printf("giza_viewport: xmin %f xmax %f ymin %f ymax %f \n",xleft,xright,ybottom,ytop);


### PR DESCRIPTION
fixes several bugs found in testing the new /osx device. Also an old bug that affected both this one and the /xw driver related to resizing the plotting window.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed interactive window resizing so rendering surfaces are recreated with the latest window/view size.
  * Improved mouse and keyboard coordinate conversion for more accurate input handling.
  * Ensured viewport and paper-size queries use up-to-date interactive window dimensions.

* **Refactoring**
  * Updated macOS and X11 interactive draw flows to centrally synchronize window sizing and reinitialize drawing layers/surfaces after size or page changes.
  * Adjusted margin-aware coordinate/clipping behavior for consistent drawing layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->