### PR TITLE
Fix broken colourblind palette documentation URL

### DIFF
--- a/docs/documentation/api.html
+++ b/docs/documentation/api.html
@@ -1377,7 +1377,7 @@
 </tr><tr>
 <td>2 to 4 :</td><td>various experimental line palettes</td>
 </tr><tr>
-<td>5 :</td><td>colourblind safe palette from http://jfly.iam.u-tokyo.ac.jp/color/</td>
+<td>5 :</td><td>colourblind safe palette from https://jfly.uni-koeln.de/color/</td>
 </tr><tr>
 <td>6 :</td><td>optimum palette from http://web.media.mit.edu/~wad/color/palette.html</td>
 </tr><tr>

--- a/src/giza-colour-palette.c
+++ b/src/giza-colour-palette.c
@@ -46,7 +46,7 @@
  *  -0 or GIZA_COLOUR_PALETTE_DEFAULT :- default giza palette
  *  -1 or GIZA_COLOUR_PALETTE_PGPLOT  :- default PGPLOT palette
  *  -2 to 4 :- various experimental line palettes
- *  -5 :- colourblind safe palette from http://jfly.iam.u-tokyo.ac.jp/color/
+ *  -5 :- colourblind safe palette from https://jfly.uni-koeln.de/color/
  *  -6 :- optimum palette from http://web.media.mit.edu/~wad/color/palette.html
  *  -7 :- graph-a-licious
  * See Also: giza_set_colour_index, giza_set_colour_table
@@ -124,7 +124,7 @@ giza_set_colour_palette (int palette)
        giza_set_colour_representation_rgb (8, 249, 223, 11); /* desert sun */
        nlinecolours = 9;
        break;
-    case 5: /* Colourblind-safe palette from http://jfly.iam.u-tokyo.ac.jp/color/ */
+    case 5: /* Colourblind-safe palette from https://jfly.uni-koeln.de/color/ */
        giza_set_colour_representation (2, 0.9, 0.6, 0.); /* orange */
        giza_set_colour_representation (3, 0.35, 0.7, 0.9); /* sky blue */
        giza_set_colour_representation (4, 0., 0.6, 0.5);  /* bluish green */


### PR DESCRIPTION
## Summary
- Replace the dead `http://jfly.iam.u-tokyo.ac.jp/color/` link with the current Color Universal Design page at `https://jfly.uni-koeln.de/color/`
- Update both the source comments in `giza-colour-palette.c` and the API reference in `docs/documentation/api.html`

## Test plan
- [x] Verified no remaining references to `jfly.iam.u-tokyo.ac.jp` in `src/` or `docs/`
- [x] Confirm the new URL loads in a browser

Fixes #78

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated colourblind-safe color palette documentation links to use secure HTTPS connections and point to the current reference source.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->