### PR TITLE
Fix pggray colour inversion and apply PGPLOT color palette defaults (from perl-pgplot tests)

### DIFF
--- a/docs/documentation/api.html
+++ b/docs/documentation/api.html
@@ -62,6 +62,8 @@
 <dd><a href="#giza_arrow_float">giza_arrow_float</a></dd>
 <dd><a href="#giza_axis">giza_axis</a></dd>
 <dd><a href="#giza_axis_float">giza_axis_float</a></dd>
+<dd><a href="#giza_box">giza_box</a></dd>
+<dd><a href="#giza_box_float">giza_box_float</a></dd>
 <dd><a href="#giza_box_time">giza_box_time</a></dd>
 <dd><a href="#giza_box_time_float">giza_box_time_float</a></dd>
 <dd><a href="#giza_box">giza_box</a></dd>
@@ -107,6 +109,8 @@
 <dd><a href="#giza_render_alpha_float">giza_render_alpha_float</a></dd>
 <dd><a href="#giza_render_gray">giza_render_gray</a></dd>
 <dd><a href="#giza_render_gray_float">giza_render_gray_float</a></dd>
+<dd><a href="#giza_render_gray_shade">giza_render_gray_shade</a></dd>
+<dd><a href="#giza_render_gray_shade_float">giza_render_gray_shade_float</a></dd>
 <dd><a href="#giza_draw_pixels">giza_draw_pixels</a></dd>
 <dd><a href="#giza_draw_pixels_float">giza_draw_pixels_float</a></dd>
 <dd><a href="#giza_tick">giza_tick</a></dd>
@@ -227,7 +231,7 @@
 </dl><a name="Device_managment"></a><h1>Device Managment</h1>
 <h3><a name="giza_device_has_cursor">giza_device_has_cursor</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>int</td><td width=20%>giza_device_has_cursor</td><td> (void) ;</tr></table><p>Query the interactivity of the device.</p>
+<tr><td width=10%>int</td><td width=20%>giza_device_has_cursor</td><td> (void) ;</td></tr></table><p>Query the interactivity of the device.</p>
 <h4>Return:</h4>
 <table class="api"><tr>
 <td>0 :</td><td>If the device is not interactive.</td>
@@ -235,28 +239,28 @@
 <td>1 :</td><td>If the device is interactive.</td>
 </tr></table><h3><a name="giza_open_device_cairo">giza_open_device_cairo</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>int</td><td width=20%>giza_open_device_cairo</td><td> (void) ;</tr></table><p>Opens an external cairo device with default logical size (800x600 px). Call giza_set_cairo_context before plotting.</p>
+<tr><td width=10%>int</td><td width=20%>giza_open_device_cairo</td><td> (void) ;</td></tr></table><p>Opens an external cairo device with default logical size (800x600 px). Call giza_set_cairo_context before plotting.</p>
 <h4>See Also:</h4><p><a href="#giza_open_device_size_cairo">giza_open_device_size_cairo</a> <a href="#giza_set_cairo_context">giza_set_cairo_context</a> </p><h3><a name="giza_open_device_size_cairo">giza_open_device_size_cairo</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>int</td><td width=20%>giza_open_device_size_cairo</td><td> (double width, double height, int units) ;</tr></table><p>Opens an external cairo device with the given logical size. Call giza_set_cairo_context before plotting.</p>
+<tr><td width=10%>int</td><td width=20%>giza_open_device_size_cairo</td><td> (double width, double height, int units) ;</td></tr></table><p>Opens an external cairo device with the given logical size. Call giza_set_cairo_context before plotting.</p>
 <h3><a name="giza_open_device_size_cairo_float">giza_open_device_size_cairo_float</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>int</td><td width=20%>giza_open_device_size_cairo_float</td><td> (float width, float height, int units) ;</tr></table><p>Same as giza_open_device_size_cairo but takes floats.</p>
+<tr><td width=10%>int</td><td width=20%>giza_open_device_size_cairo_float</td><td> (float width, float height, int units) ;</td></tr></table><p>Same as giza_open_device_size_cairo but takes floats.</p>
 <h4>See Also:</h4><p><a href="#giza_open_device_size_cairo">giza_open_device_size_cairo</a> </p><h3><a name="giza_set_cairo_context">giza_set_cairo_context</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>int</td><td width=20%>giza_set_cairo_context</td><td> (cairo_t *cr) ;</tr></table><p>Bind a caller-owned cairo_t for the current frame. Performs cairo_save so giza_release_cairo_context can restore GTK state.</p>
+<tr><td width=10%>int</td><td width=20%>giza_set_cairo_context</td><td> (cairo_t *cr) ;</td></tr></table><p>Bind a caller-owned cairo_t for the current frame. Performs cairo_save so giza_release_cairo_context can restore GTK state.</p>
 <h3><a name="giza_release_cairo_context">giza_release_cairo_context</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>int</td><td width=20%>giza_release_cairo_context</td><td> (void) ;</tr></table><p>End a frame of drawing to an external cairo context. Restores the caller's cairo state and clears the cached pointer.</p>
+<tr><td width=10%>int</td><td width=20%>giza_release_cairo_context</td><td> (void) ;</td></tr></table><p>End a frame of drawing to an external cairo context. Restores the caller's cairo state and clears the cached pointer.</p>
 <h3><a name="giza_resize_device_cairo">giza_resize_device_cairo</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>int</td><td width=20%>giza_resize_device_cairo</td><td> (double width, double height, int units) ;</tr></table><p>Update logical device size after a widget resize.</p>
+<tr><td width=10%>int</td><td width=20%>giza_resize_device_cairo</td><td> (double width, double height, int units) ;</td></tr></table><p>Update logical device size after a widget resize.</p>
 <h3><a name="giza_get_cairo_surface">giza_get_cairo_surface</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>cairo_surface_t *</td><td width=20%>giza_get_cairo_surface</td><td> (void) ;</tr></table><p>Return the cairo surface currently bound to the device. Valid while the device is open; do not destroy the returned surface.</p>
+<tr><td width=10%>cairo_surface_t *</td><td width=20%>giza_get_cairo_surface</td><td> (void) ;</td></tr></table><p>Return the cairo surface currently bound to the device. Valid while the device is open; do not destroy the returned surface.</p>
 <h3><a name="giza_open_device">giza_open_device</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>int</td><td width=20%>giza_open_device</td><td> (const char *newDeviceName, const char *newPrefix) ;</tr></table><p>Opens a new device to be drawn to. Must be called before any drawing can take place.</p>
+<tr><td width=10%>int</td><td width=20%>giza_open_device</td><td> (const char *newDeviceName, const char *newPrefix) ;</td></tr></table><p>Opens a new device to be drawn to. Must be called before any drawing can take place.</p>
 <h4>Input:</h4>
 <table class="api"><tr>
 <td>newDeviceName :</td><td>Specifies the name and type of device to be opened. See below for details.</td>
@@ -264,7 +268,7 @@
 <td>newPrefix     :</td><td>Specifies the default prefix to be used for file names.</td>
 </tr></table><h4>Return value:</h4>
 <table class="api"><tr>
-<td><=0 :</td><td>an error has occurred</td>
+<td>&lt;=0 :</td><td>an error has occurred</td>
 </tr><tr>
 <td>1   :</td><td>id of current device Note: this is the EXTERNAL device number, running from 1..Ndev The internal device numbers are array indices into the Dev[...] array and run from 0..Ndev-1</td>
 </tr></table><h4>Available devices:</h4>
@@ -291,7 +295,7 @@
 </tr></table><h4>e.g:</h4>
 <table class="api"></table><h4>See Also:</h4><p><a href="#giza_select_device">giza_select_device</a> <a href="#giza_get_device_id">giza_get_device_id</a> <a href="#giza_close_device">giza_close_device</a> <a href="#giza_query_device">giza_query_device</a> </p><h3><a name="giza_open_device_size">giza_open_device_size</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>int</td><td width=20%>giza_open_device_size</td><td> (const char *newDeviceName, const char *newPrefix, double width, double height, int units) ;</tr></table><p>Similar to giza_open_device, but allows one to specify the size of the device</p>
+<tr><td width=10%>int</td><td width=20%>giza_open_device_size</td><td> (const char *newDeviceName, const char *newPrefix, double width, double height, int units) ;</td></tr></table><p>Similar to giza_open_device, but allows one to specify the size of the device</p>
 <h4>Input:</h4>
 <table class="api"><tr>
 <td>newDeviceName :</td><td>Specifies the type of device to be opened. See below for details.</td>
@@ -314,32 +318,32 @@
 <td>GIZA_UNITS_INCHES     :</td><td>inches Other values cause an error message and are treated as GIZA_UNITS_DEVICE</td>
 </tr></table><h4>See Also:</h4><p><a href="#giza_open_device">giza_open_device</a> </p><h3><a name="giza_open_device_size_float">giza_open_device_size_float</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>int</td><td width=20%>giza_open_device_size_float</td><td> (const char *newDeviceName, const char *newPrefix, float width, float height, int units) ;</tr></table><p>Same functionality as giza_open_device_size but takes floats</p>
+<tr><td width=10%>int</td><td width=20%>giza_open_device_size_float</td><td> (const char *newDeviceName, const char *newPrefix, float width, float height, int units) ;</td></tr></table><p>Same functionality as giza_open_device_size but takes floats</p>
 <h3><a name="giza_get_device_id">giza_get_device_id</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_get_device_id</td><td> (int *devid) ;</tr></table><p>Returns the (external) id of the currently selected device</p>
+<tr><td width=10%>void</td><td width=20%>giza_get_device_id</td><td> (int *devid) ;</td></tr></table><p>Returns the (external) id of the currently selected device</p>
 <h4>Output:</h4>
 <table class="api"></table><h4>See Also:</h4><p><a href="#giza_open_device">giza_open_device</a> <a href="#giza_get_device_id">giza_get_device_id</a> </p><h3><a name="giza_select_device">giza_select_device</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_select_device</td><td> (int devid) ;</tr></table><p>Select between the currently open devices</p>
+<tr><td width=10%>void</td><td width=20%>giza_select_device</td><td> (int devid) ;</td></tr></table><p>Select between the currently open devices</p>
 <h4>Input:</h4>
 <table class="api"><tr>
 <td>devid :</td><td>device id, as returned by giza_open_device</td>
 </tr></table><h4>See Also:</h4><p><a href="#giza_get_device_id">giza_get_device_id</a> <a href="#giza_open_device">giza_open_device</a> </p><h3><a name="giza_flush_device">giza_flush_device</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_flush_device</td><td> (void) ;</tr></table><p>Flushes the currently open device.</p>
+<tr><td width=10%>void</td><td width=20%>giza_flush_device</td><td> (void) ;</td></tr></table><p>Flushes the currently open device.</p>
 <h3><a name="giza_change_page">giza_change_page</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_change_page</td><td> (void) ;</tr></table><p>Advances the currently open device to the next page, and redraws the background. If no other actions have been performed since the device was opened or the last call to giza_change_page the call is ignored.</p>
+<tr><td width=10%>void</td><td width=20%>giza_change_page</td><td> (void) ;</td></tr></table><p>Advances the currently open device to the next page, and redraws the background. If no other actions have been performed since the device was opened or the last call to giza_change_page the call is ignored.</p>
 <h4>See Also:</h4><p><a href="#giza_subpanel">giza_subpanel</a> <a href="#giza_set_panel">giza_set_panel</a> </p><h3><a name="giza_close_devices">giza_close_devices</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_close_devices</td><td> (void) ;</tr></table><p>Close all open devices (to be called from PGEND())</p>
+<tr><td width=10%>void</td><td width=20%>giza_close_devices</td><td> (void) ;</td></tr></table><p>Close all open devices (to be called from PGEND())</p>
 <h3><a name="giza_close_device">giza_close_device</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_close_device</td><td> (void) ;</tr></table><p>Closes the currently open device. Should always be called before exiting your program as it frees associated memory.</p>
+<tr><td width=10%>void</td><td width=20%>giza_close_device</td><td> (void) ;</td></tr></table><p>Closes the currently open device. Should always be called before exiting your program as it frees associated memory.</p>
 <h3><a name="giza_query_device">giza_query_device</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>int</td><td width=20%>giza_query_device</td><td> (const char *querytype, char *returnval, int* rlen) ;</tr></table><p>Queries various things about the current device.</p>
+<tr><td width=10%>int</td><td width=20%>giza_query_device</td><td> (const char *querytype, char *returnval, int* rlen) ;</td></tr></table><p>Queries various things about the current device.</p>
 <h4>Input:</h4>
 <table class="api"><tr>
 <td>querytype :</td><td>a string containing the query type</td>
@@ -359,16 +363,16 @@
 <table class="api"></table><h4>"hardcopy" :</h4>
 <table class="api"></table><h3><a name="giza_set_motion_callback">giza_set_motion_callback</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>int</td><td width=20%>giza_set_motion_callback</td><td> (void (*func)(double *x, double *y, int *mode)) ;</tr></table><p>set a callback function to be called during cursor movement (e.g. to print things). Function should be of the form void func(double *x, double *y)</p>
+<tr><td width=10%>int</td><td width=20%>giza_set_motion_callback</td><td> (void (*func)(double *x, double *y, int *mode)) ;</td></tr></table><p>set a callback function to be called during cursor movement (e.g. to print things). Function should be of the form void func(double *x, double *y)</p>
 <h4>Input:</h4>
 <table class="api"><tr>
 <td>func  :</td><td>The subroutine to be called</td>
 </tr></table><h4>See Also:</h4><p><a href="#giza_end_motion_callback">giza_end_motion_callback</a> </p><h3><a name="giza_end_motion_callback">giza_end_motion_callback</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>int</td><td width=20%>giza_end_motion_callback</td><td> (void) ;</tr></table><p>Free the motion callback pointer</p>
+<tr><td width=10%>int</td><td width=20%>giza_end_motion_callback</td><td> (void) ;</td></tr></table><p>Free the motion callback pointer</p>
 <h4>See Also:</h4><p><a href="#giza_set_motion_callback">giza_set_motion_callback</a> </p><h3><a name="giza_get_surface_size">giza_get_surface_size</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_get_surface_size</td><td> (double *x1, double *x2, double *y1, double *y2) ;</tr></table><p>Gets the size of the current surface that can be drawn to in device units (pixels or points).</p>
+<tr><td width=10%>void</td><td width=20%>giza_get_surface_size</td><td> (double *x1, double *x2, double *y1, double *y2) ;</td></tr></table><p>Gets the size of the current surface that can be drawn to in device units (pixels or points).</p>
 <h4>Input:</h4>
 <table class="api"><tr>
 <td>x1 :</td><td>Always gets set to 0.0</td>
@@ -380,10 +384,10 @@
 <td>y2 :</td><td>Gets set to the width of the surface</td>
 </tr></table><h3><a name="giza_get_surface_size_float">giza_get_surface_size_float</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_get_surface_size_float</td><td> (float *x1, float *x2, float *y1, float *y2) ;</tr></table><p>Same functionality as giza_get_surface_size, but uses floats.</p>
+<tr><td width=10%>void</td><td width=20%>giza_get_surface_size_float</td><td> (float *x1, float *x2, float *y1, float *y2) ;</td></tr></table><p>Same functionality as giza_get_surface_size, but uses floats.</p>
 <h4>See Also:</h4><p><a href="#giza_get_surface_size">giza_get_surface_size</a> </p><h3><a name="giza_histogram">giza_histogram</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_histogram</td><td> (int n, const double *dat, double min, double max, int nbin, int flag) ;</tr></table><p>Plot a histogram (unbinned)</p>
+<tr><td width=10%>void</td><td width=20%>giza_histogram</td><td> (int n, const double *dat, double min, double max, int nbin, int flag) ;</td></tr></table><p>Plot a histogram (unbinned)</p>
 <h4>Input:</h4>
 <table class="api"><tr>
 <td>n    :</td><td>number of data values</td>
@@ -412,10 +416,10 @@
 <td>5   :</td><td>bins drawn as simple outlines, but in current window and viewport Other values treated as 1</td>
 </tr></table><h4>See Also:</h4><p><a href="#giza_histogram_binned">giza_histogram_binned</a> <a href="#giza_histogram_float">giza_histogram_float</a> </p><h3><a name="giza_histogram_float">giza_histogram_float</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_histogram_float</td><td> (int n, const float *dat, float min, float max, int nbin, int flag) ;</tr></table><p>Same as giza_histogram but takes floats</p>
+<tr><td width=10%>void</td><td width=20%>giza_histogram_float</td><td> (int n, const float *dat, float min, float max, int nbin, int flag) ;</td></tr></table><p>Same as giza_histogram but takes floats</p>
 <h4>See Also:</h4><p><a href="#giza_histogram">giza_histogram</a> <a href="#giza_histogram_binned_float">giza_histogram_binned_float</a> </p><h3><a name="giza_histogram_binned">giza_histogram_binned</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_histogram_binned</td><td> (int n, const double *x, const double *dat, int centre) ;</tr></table><p>Plot a histogram of already binned data</p>
+<tr><td width=10%>void</td><td width=20%>giza_histogram_binned</td><td> (int n, const double *x, const double *dat, int centre) ;</td></tr></table><p>Plot a histogram of already binned data</p>
 <h4>Input:</h4>
 <table class="api"><tr>
 <td>n      :</td><td>number of bins</td>
@@ -427,10 +431,10 @@
 <td>center :</td><td>if true (1) x values correspond to centre of each bin</td>
 </tr></table><h4>See Also:</h4><p><a href="#giza_histogram">giza_histogram</a> <a href="#giza_histogram_binned_float">giza_histogram_binned_float</a> </p><h3><a name="giza_histogram_binned_float">giza_histogram_binned_float</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_histogram_binned_float</td><td> (int n, const float *x, const float *dat, int centre) ;</tr></table><p>Same as giza_histogram_binned but takes floats</p>
+<tr><td width=10%>void</td><td width=20%>giza_histogram_binned_float</td><td> (int n, const float *x, const float *dat, int centre) ;</td></tr></table><p>Same as giza_histogram_binned but takes floats</p>
 <h4>See Also:</h4><p><a href="#giza_histogram">giza_histogram</a> <a href="#giza_histogram_binned_float">giza_histogram_binned_float</a> </p><h3><a name="giza_subpanel">giza_subpanel</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_subpanel</td><td> (int nx, int ny) ;</tr></table><p>Set the number of sub panels</p>
+<tr><td width=10%>void</td><td width=20%>giza_subpanel</td><td> (int nx, int ny) ;</td></tr></table><p>Set the number of sub panels</p>
 <h4>Input:</h4>
 <table class="api"><tr>
 <td>nx :</td><td>number of sub-panels in x direction</td>
@@ -438,7 +442,7 @@
 <td>ny :</td><td>number of sub panels in y direction</td>
 </tr></table><h4>See Also:</h4><p><a href="#giza_select_panel">giza_select_panel</a> <a href="#giza_get_panel">giza_get_panel</a> </p><h3><a name="giza_set_panel">giza_set_panel</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_set_panel</td><td> (int ix, int iy) ;</tr></table><p>Select the panel we are currently plotting in</p>
+<tr><td width=10%>void</td><td width=20%>giza_set_panel</td><td> (int ix, int iy) ;</td></tr></table><p>Select the panel we are currently plotting in</p>
 <h4>Input:</h4>
 <table class="api"><tr>
 <td>ix :</td><td>panel index in x direction</td>
@@ -446,7 +450,7 @@
 <td>iy :</td><td>panel index in y direction</td>
 </tr></table><h4>See Also:</h4><p><a href="#giza_subpanel">giza_subpanel</a> <a href="#giza_get_panel">giza_get_panel</a> </p><h3><a name="giza_get_panel">giza_get_panel</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_get_panel</td><td> (int *ix, int *iy) ;</tr></table><p>Select the panel we are currently plotting in</p>
+<tr><td width=10%>void</td><td width=20%>giza_get_panel</td><td> (int *ix, int *iy) ;</td></tr></table><p>Select the panel we are currently plotting in</p>
 <h4>Input:</h4>
 <table class="api"><tr>
 <td>ix :</td><td>panel index in x direction</td>
@@ -454,14 +458,14 @@
 <td>iy :</td><td>panel index in y direction</td>
 </tr></table><h4>See Also:</h4><p><a href="#giza_subpanel">giza_subpanel</a> <a href="#giza_set_panel">giza_set_panel</a> </p><h3><a name="giza_init_subpanel">giza_init_subpanel</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>_giza_init_subpanel</td><td> () ;</tr></table><p>initialises subpanel settings for device</p>
+<tr><td width=10%>void</td><td width=20%>_giza_init_subpanel</td><td> () ;</td></tr></table><p>initialises subpanel settings for device</p>
 <h3><a name="giza_advance_panel">giza_advance_panel</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>_giza_advance_panel</td><td> (int *newpage) ;</tr></table><p>Moves to next panel</p>
+<tr><td width=10%>void</td><td width=20%>_giza_advance_panel</td><td> (int *newpage) ;</td></tr></table><p>Moves to next panel</p>
 <a name="Drawing"></a><h1>Drawing</h1>
 <h3><a name="giza_arrow">giza_arrow</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_arrow</td><td> (double x1, double y1, double x2, double y2) ;</tr></table><p>Draws an arrow. The style of the head of the arrow is set by giza_set_arrow_style.</p>
+<tr><td width=10%>void</td><td width=20%>giza_arrow</td><td> (double x1, double y1, double x2, double y2) ;</td></tr></table><p>Draws an arrow. The style of the head of the arrow is set by giza_set_arrow_style.</p>
 <h4>Input:</h4>
 <table class="api"><tr>
 <td>x1 :</td><td>The world x-coord of the tail of the arrow</td>
@@ -473,10 +477,10 @@
 <td>y2 :</td><td>The world y-coord of the head of the arrow</td>
 </tr></table><h4>See Also:</h4><p><a href="#giza_set_arrow_style">giza_set_arrow_style</a> <a href="#giza_arrow_float">giza_arrow_float</a> </p><h3><a name="giza_arrow_float">giza_arrow_float</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_arrow_float</td><td> (float x1, float y1, float x2, float y2) ;</tr></table><p>Same functionality as giza_arrow.</p>
+<tr><td width=10%>void</td><td width=20%>giza_arrow_float</td><td> (float x1, float y1, float x2, float y2) ;</td></tr></table><p>Same functionality as giza_arrow.</p>
 <h4>See Also:</h4><p><a href="#giza_arrow">giza_arrow</a> <a href="#giza_set_arrow_style">giza_set_arrow_style</a> </p><h3><a name="giza_axis">giza_axis</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_axis</td><td> (const char *opt, double x1, double y1, double x2, double y2, double v1, double v2, double tick, int nsub, double dmajl, double dmajr, double fmin, double disp, double angle) ;</tr></table><p>Draw a labelled axis from (x1,y1) to (x2,y2)</p>
+<tr><td width=10%>void</td><td width=20%>giza_axis</td><td> (const char *opt, double x1, double y1, double x2, double y2, double v1, double v2, double tick, int nsub, double dmajl, double dmajr, double fmin, double disp, double angle) ;</td></tr></table><p>Draw a labelled axis from (x1,y1) to (x2,y2)</p>
 <h4>Input:</h4>
 <table class="api"><tr>
 <td>opt  :</td><td>String of options for the axis. The options may be in any order. See below for details</td>
@@ -525,44 +529,10 @@
 <td>2 :</td><td>Force exponential labelling instead of automatic choice (see giza_format_number)</td>
 </tr></table><h4>See Also:</h4><p><a href="#giza_axis_float">giza_axis_float</a> <a href="#giza_box">giza_box</a> <a href="#giza_tick">giza_tick</a> <a href="#giza_box_time">giza_box_time</a> </p><h3><a name="giza_axis_float">giza_axis_float</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_axis_float</td><td> (const char *opt, float x1, float y1, float x2, float y2, float v1, float v2, float step, int nsub, float dmajl, float dmajr, float fmin, float disp, float angle) ;</tr></table><p>Same functionality as giza_axis but takes floats instead of doubles.</p>
-<h4>See Also:</h4><p><a href="#giza_axis">giza_axis</a> </p><h3><a name="giza_box_time">giza_box_time</a><hr></h3>
+<tr><td width=10%>void</td><td width=20%>giza_axis_float</td><td> (const char *opt, float x1, float y1, float x2, float y2, float v1, float v2, float step, int nsub, float dmajl, float dmajr, float fmin, float disp, float angle) ;</td></tr></table><p>Same functionality as giza_axis but takes floats instead of doubles.</p>
+<h4>See Also:</h4><p><a href="#giza_axis">giza_axis</a> </p><h3><a name="giza_box">giza_box</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>    void</td><td width=20%></td><td>     giza_box_time (const char *xopt, double xtick, int nxsub, const char *yopt, double ytick, int nysub) ;</tr></table><p>Same as giza_box, but labels axes with time-style labels i.e. DD HH MM SS as used in RA - DEC plots for Astronomy. If this option is used then giza_set_window should have been called with min/max given in seconds of time.</p>
-<h4>Input:</h4>
-<table class="api"><tr>
-<td>xopt  :</td><td>As for giza_box, plus additional options below</td>
-</tr><tr>
-<td>xtick :</td><td>The distance, in world coordinates, between major ticks on the x-axis. If 0.0 the interval is chosen by giza_box_time.</td>
-</tr><tr>
-<td>nxsub :</td><td>The number of minor ticks to be placed between each major tick. If 0 the number is chosen by giza_box.</td>
-</tr><tr>
-<td>yopt  :</td><td>Similar to xdraw_minticks but for the y-axis.</td>
-</tr><tr>
-<td>ytick :</td><td>Similar to xtick but for the y-axis.</td>
-</tr><tr>
-<td>nysub :</td><td>Similar to nxsub but for the y-axis.</td>
-</tr></table><h4>Options for xopt and yopt (same as for giza_box, plus those below):</h4>
-<table class="api"><tr>
-<td>Z :</td><td>for time-style labelling: (DD) HH MM SS.S</td>
-</tr><tr>
-<td>Y :</td><td>exclude the day field so labels are just HH MM SS.S (hours can be >24)</td>
-</tr><tr>
-<td>X :</td><td>keep HH field in range (0..24)</td>
-</tr><tr>
-<td>H :</td><td>use d,h,m,s superscripts to label numbers</td>
-</tr><tr>
-<td>D :</td><td>use degree o, minute ' and second '' superscripts to label numbers</td>
-</tr><tr>
-<td>F :</td><td>do not draw the first label (left- or bottom-most)</td>
-</tr><tr>
-<td>O :</td><td>omit leading zeros in numbers < 10, i.e. 3 instead of 03</td>
-</tr></table><h4>See Also:</h4><p><a href="#giza_box">giza_box</a> <a href="#giza_box_float">giza_box_float</a> <a href="#giza_box_time_float">giza_box_time_float</a> </p><h3><a name="giza_box_time_float">giza_box_time_float</a><hr></h3>
-<table class="proto">
-<tr><td width=10%>    void</td><td width=20%>giza_box_time_float</td><td> (const char *xopt, float xtick, int nxsub, const char *yopt, float ytick, int nysub) ;</tr></table><p>Same functionality as giza_box_time but takes floats instead of doubles.</p>
-<h4>See Also:</h4><p><a href="#giza_box_time">giza_box_time</a> <a href="#giza_box">giza_box</a> </p><h3><a name="giza_box">giza_box</a><hr></h3>
-<table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_box</td><td> (const char *xopt, double xtick, int nxsub, const char *yopt, double ytick, int nysub) ;</tr></table><p>Annotates the viewport with labelled axis/frame</p>
+<tr><td width=10%>void</td><td width=20%>giza_box</td><td> (const char *xopt, double xtick, int nxsub, const char *yopt, double ytick, int nysub) ;</td></tr></table><p>Annotates the viewport with labelled axis/frame</p>
 <h4>Input:</h4>
 <table class="api"><tr>
 <td>xopt  :</td><td>String of options for the x-axis. The options may be in any order. See below for details</td>
@@ -605,10 +575,90 @@
 <td>P :</td><td>extend ("Project") major tick marks outside the box (ignored if option I is specified).</td>
 </tr></table><h3><a name="giza_box_float">giza_box_float</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_box_float</td><td> (const char *xopt, float xtick, int nxsub, const char *yopt, float ytick, int nysub) ;</tr></table><p>Same functionality as giza_box but takes floats instead of doubles.</p>
+<tr><td width=10%>void</td><td width=20%>giza_box_float</td><td> (const char *xopt, float xtick, int nxsub, const char *yopt, float ytick, int nysub) ;</td></tr></table><p>Same functionality as giza_box but takes floats instead of doubles.</p>
+<h4>See Also:</h4><p><a href="#giza_box">giza_box</a> </p><h3><a name="giza_box_time">giza_box_time</a><hr></h3>
+<table class="proto">
+<tr><td width=10%>    void</td><td width=20%></td><td>     giza_box_time (const char *xopt, double xtick, int nxsub, const char *yopt, double ytick, int nysub) ;</td></tr></table><p>Same as giza_box, but labels axes with time-style labels i.e. DD HH MM SS as used in RA - DEC plots for Astronomy. If this option is used then giza_set_window should have been called with min/max given in seconds of time.</p>
+<h4>Input:</h4>
+<table class="api"><tr>
+<td>xopt  :</td><td>As for giza_box, plus additional options below</td>
+</tr><tr>
+<td>xtick :</td><td>The distance, in world coordinates, between major ticks on the x-axis. If 0.0 the interval is chosen by giza_box_time.</td>
+</tr><tr>
+<td>nxsub :</td><td>The number of minor ticks to be placed between each major tick. If 0 the number is chosen by giza_box.</td>
+</tr><tr>
+<td>yopt  :</td><td>Similar to xdraw_minticks but for the y-axis.</td>
+</tr><tr>
+<td>ytick :</td><td>Similar to xtick but for the y-axis.</td>
+</tr><tr>
+<td>nysub :</td><td>Similar to nxsub but for the y-axis.</td>
+</tr></table><h4>Options for xopt and yopt (same as for giza_box, plus those below):</h4>
+<table class="api"><tr>
+<td>Z :</td><td>for time-style labelling: (DD) HH MM SS.S</td>
+</tr><tr>
+<td>Y :</td><td>exclude the day field so labels are just HH MM SS.S (hours can be &gt;24)</td>
+</tr><tr>
+<td>X :</td><td>keep HH field in range (0..24)</td>
+</tr><tr>
+<td>H :</td><td>use d,h,m,s superscripts to label numbers</td>
+</tr><tr>
+<td>D :</td><td>use degree o, minute ' and second '' superscripts to label numbers</td>
+</tr><tr>
+<td>F :</td><td>do not draw the first label (left- or bottom-most)</td>
+</tr><tr>
+<td>O :</td><td>omit leading zeros in numbers &lt; 10, i.e. 3 instead of 03</td>
+</tr></table><h4>See Also:</h4><p><a href="#giza_box">giza_box</a> <a href="#giza_box_float">giza_box_float</a> <a href="#giza_box_time_float">giza_box_time_float</a> </p><h3><a name="giza_box_time_float">giza_box_time_float</a><hr></h3>
+<table class="proto">
+<tr><td width=10%>    void</td><td width=20%>giza_box_time_float</td><td> (const char *xopt, float xtick, int nxsub, const char *yopt, float ytick, int nysub) ;</td></tr></table><p>Same functionality as giza_box_time but takes floats instead of doubles.</p>
+<h4>See Also:</h4><p><a href="#giza_box_time">giza_box_time</a> <a href="#giza_box">giza_box</a> </p><h3><a name="giza_box">giza_box</a><hr></h3>
+<table class="proto">
+<tr><td width=10%>void</td><td width=20%>giza_box</td><td> (const char *xopt, double xtick, int nxsub, const char *yopt, double ytick, int nysub) ;</td></tr></table><p>Annotates the viewport with labelled axis/frame</p>
+<h4>Input:</h4>
+<table class="api"><tr>
+<td>xopt  :</td><td>String of options for the x-axis. The options may be in any order. See below for details</td>
+</tr><tr>
+<td>xtick :</td><td>The distance, in world coordinates, between major ticks on the x-axis. If 0.0 the interval is chosen by giza_box.</td>
+</tr><tr>
+<td>nxsub :</td><td>The number of minor ticks to be placed between each major tick. If 0 the number is chosen by giza_box.</td>
+</tr><tr>
+<td>yopt  :</td><td>Similar to xopt but for the y-axis.</td>
+</tr><tr>
+<td>ytick :</td><td>Similar to xtick but for the y-axis.</td>
+</tr><tr>
+<td>nysub :</td><td>Similar to nxsub but for the y-axis.</td>
+</tr></table><h4>Options:</h4>
+<table class="api"><tr>
+<td>A :</td><td>Draw the axis.</td>
+</tr><tr>
+<td>B :</td><td>Draw the bottom or left edge of the frame.</td>
+</tr><tr>
+<td>C :</td><td>Draw the top or right edge of the frame.</td>
+</tr><tr>
+<td>T :</td><td>Draw major ticks.</td>
+</tr><tr>
+<td>S :</td><td>Draw minor ticks.</td>
+</tr><tr>
+<td>N :</td><td>Label the axis (conventional, below/left viewport)</td>
+</tr><tr>
+<td>M :</td><td>Put labels in the unconvential location (above/right viewport)</td>
+</tr><tr>
+<td>V :</td><td>Orient numeric y labels vertically (only applies to left and right axis).</td>
+</tr><tr>
+<td>G :</td><td>Draw grid lines at major intervals</td>
+</tr><tr>
+<td>M :</td><td>Write numeric labels above x-axis or to right of y-axis instead of usual position</td>
+</tr><tr>
+<td>L :</td><td>Label axis logarithmically</td>
+</tr><tr>
+<td>I :</td><td>'Invert' tick marks, draw them outside the viewport</td>
+</tr><tr>
+<td>P :</td><td>extend ("Project") major tick marks outside the box (ignored if option I is specified).</td>
+</tr></table><h3><a name="giza_box_float">giza_box_float</a><hr></h3>
+<table class="proto">
+<tr><td width=10%>void</td><td width=20%>giza_box_float</td><td> (const char *xopt, float xtick, int nxsub, const char *yopt, float ytick, int nysub) ;</td></tr></table><p>Same functionality as giza_box but takes floats instead of doubles.</p>
 <h4>See Also:</h4><p><a href="#giza_box">giza_box</a> </p><h3><a name="giza_circle">giza_circle</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_circle</td><td> (double x, double y, double r) ;</tr></table><p>Draws a circle at x, y with radius r (in world coords), using the current fill set by giza_set_fill.</p>
+<tr><td width=10%>void</td><td width=20%>giza_circle</td><td> (double x, double y, double r) ;</td></tr></table><p>Draws a circle at x, y with radius r (in world coords), using the current fill set by giza_set_fill.</p>
 <h4>Input:</h4>
 <table class="api"><tr>
 <td>x    :</td><td>the world x-coord of the centre of the circle</td>
@@ -618,26 +668,26 @@
 <td>r    :</td><td>the radius of the circle in world coords</td>
 </tr></table><h3><a name="giza_circle_float">giza_circle_float</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_circle_float</td><td> (float x, float y, float r) ;</tr></table><p>Same functionality as giza_circle, but takes floats</p>
+<tr><td width=10%>void</td><td width=20%>giza_circle_float</td><td> (float x, float y, float r) ;</td></tr></table><p>Same functionality as giza_circle, but takes floats</p>
 <h4>See Also:</h4><p><a href="#giza_circle">giza_circle</a> </p><h3><a name="giza_clip">giza_clip</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_set_clipping</td><td> (int clip) ;</tr></table><p>Set whether or not to clip at the edge of the viewport</p>
+<tr><td width=10%>void</td><td width=20%>giza_set_clipping</td><td> (int clip) ;</td></tr></table><p>Set whether or not to clip at the edge of the viewport</p>
 <h4>Input:</h4>
 <table class="api"><tr>
 <td>clip :</td><td>Use 0 to disable clipping, 1 to enable clipping</td>
 </tr></table><h3><a name="giza_get_clipping">giza_get_clipping</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_get_clipping</td><td> (int *clip) ;</tr></table><p>Query whether or not clipping at edge of viewport is enabled or disabled</p>
+<tr><td width=10%>void</td><td width=20%>giza_get_clipping</td><td> (int *clip) ;</td></tr></table><p>Query whether or not clipping at edge of viewport is enabled or disabled</p>
 <h4>See Also:</h4><p><a href="#giza_move">giza_move</a> </p><h3><a name="giza_colour_bar">giza_colour_bar</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_colour_bar</td><td> (const char *side, double disp, double width,  double valMin, double valMax, const char *label) ;</tr></table><p>Draws a colour bar (wedge) using the current colour ramp</p>
+<tr><td width=10%>void</td><td width=20%>giza_colour_bar</td><td> (const char *side, double disp, double width, double valMin, double valMax, const char *label) ;</td></tr></table><p>Draws a colour bar (wedge) using the current colour ramp</p>
 <h4>Input:</h4>
 <table class="api"><tr>
 <td>side    :</td><td>edge of viewport to draw colour bar relative to, either 'B' (bottom), 'T' (top), 'L' (left) or 'R' (right)</td>
 </tr><tr>
 <td>disp    :</td><td>displacement of the bar in character heights from the specified edge</td>
 </tr><tr>
-<td>width   :</td><td>width of the colour bar in character heights</td>
+<td>width   :</td><td>total outward extent of the colour bar in character heights, including room for tick labels and an optional units label</td>
 </tr><tr>
 <td>valMin  :</td><td>The value in data that gets assigned the colour corresponding to zero on the colour ramp (The ramp is set by giza_set_colour_table)</td>
 </tr><tr>
@@ -646,13 +696,13 @@
 <td>label   :</td><td>Text label to annotate colour bar with</td>
 </tr></table><h4>See Also:</h4><p><a href="#giza_render">giza_render</a> <a href="#giza_colour_bar_float">giza_colour_bar_float</a> <a href="#giza_set_colour_table">giza_set_colour_table</a> </p><h3><a name="giza_colour_bar_float">giza_colour_bar_float</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_colour_bar_float</td><td> (const char *side, float disp, float width,  float valMin, float valMax, const char *label) ;</tr></table><p>Same functionality as giza_colour_bar, but takes floats</p>
+<tr><td width=10%>void</td><td width=20%>giza_colour_bar_float</td><td> (const char *side, float disp, float width, float valMin, float valMax, const char *label) ;</td></tr></table><p>Same functionality as giza_colour_bar, but takes floats</p>
 <h4>See Also:</h4><p><a href="#giza_colour_bar">giza_colour_bar</a> </p><h3><a name="giza_draw_background">giza_draw_background</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_draw_background</td><td> (void) ;</tr></table><p>Redraws the background of the currently open device (erase)</p>
+<tr><td width=10%>void</td><td width=20%>giza_draw_background</td><td> (void) ;</td></tr></table><p>Redraws the background of the currently open device (erase)</p>
 <h3><a name="giza_draw">giza_draw</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_draw</td><td> (double xpt, double ypt) ;</tr></table><p>Plots a line from current pen position to a point</p>
+<tr><td width=10%>void</td><td width=20%>giza_draw</td><td> (double xpt, double ypt) ;</td></tr></table><p>Plots a line from current pen position to a point</p>
 <h4>Input:</h4>
 <table class="api"><tr>
 <td>xpt :</td><td>The world x-coordinates of the point</td>
@@ -660,10 +710,10 @@
 <td>ypt :</td><td>The world y-coordinates of the point</td>
 </tr></table><h3><a name="giza_draw_float">giza_draw_float</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_draw_float</td><td> (float xpt, float ypt) ;</tr></table><p>The same functionality as giza_draw, except it uses floats</p>
+<tr><td width=10%>void</td><td width=20%>giza_draw_float</td><td> (float xpt, float ypt) ;</td></tr></table><p>The same functionality as giza_draw, except it uses floats</p>
 <h3><a name="giza_error_bars">giza_error_bars</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_error_bars</td><td> (int dir, int n, const double *xpts, const double *ypts, const double *error, double term) ;</tr></table><p>Draws error bars.</p>
+<tr><td width=10%>void</td><td width=20%>giza_error_bars</td><td> (int dir, int n, const double *xpts, const double *ypts, const double *error, double term) ;</td></tr></table><p>Draws error bars.</p>
 <h4>Input:</h4>
 <table class="api"><tr>
 <td>dir  :</td><td>the direction of the error bar, see below</td>
@@ -698,10 +748,10 @@
 <td>9 :</td><td>+y and -y using a semi-transparent shaded region</td>
 </tr></table><h3><a name="giza_error_bars_float">giza_error_bars_float</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_error_bars_float</td><td> (int dir, int n, const float *xpts, const float *ypts, const float *error, float term) ;</tr></table><p>Same as giza_error_bars but takes floats.</p>
+<tr><td width=10%>void</td><td width=20%>giza_error_bars_float</td><td> (int dir, int n, const float *xpts, const float *ypts, const float *error, float term) ;</td></tr></table><p>Same as giza_error_bars but takes floats.</p>
 <h3><a name="giza_error_bars_vert">giza_error_bars_vert</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_error_bars_vert</td><td> (int n, const double *xpts, const double *ypts1, const double *ypts2, double term) ;</tr></table><p>Draws n vertical error bars. A call to giza_points must be made to draw the actual points.</p>
+<tr><td width=10%>void</td><td width=20%>giza_error_bars_vert</td><td> (int n, const double *xpts, const double *ypts1, const double *ypts2, double term) ;</td></tr></table><p>Draws n vertical error bars. A call to giza_points must be made to draw the actual points.</p>
 <h4>Input:</h4>
 <table class="api"><tr>
 <td>n      :</td><td>the number of bars to draw</td>
@@ -712,13 +762,13 @@
 </tr><tr>
 <td>ypts2  :</td><td>the y world coords of the upper part of the error bar</td>
 </tr><tr>
-<td>term   :</td><td>length of the terminals, as a multiple of default length (T <= 0.0 means no terminals drawn)</td>
+<td>term   :</td><td>length of the terminals, as a multiple of default length (T &lt;= 0.0 means no terminals drawn)</td>
 </tr></table><h3><a name="giza_error_bars_vert_float">giza_error_bars_vert_float</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_error_bars_vert_float</td><td> (int n, const float *xpts, const float *ypts1, const float *ypts2, float term) ;</tr></table><p>Same functionality as giza_error_bars_vert but takes floats.</p>
+<tr><td width=10%>void</td><td width=20%>giza_error_bars_vert_float</td><td> (int n, const float *xpts, const float *ypts1, const float *ypts2, float term) ;</td></tr></table><p>Same functionality as giza_error_bars_vert but takes floats.</p>
 <h3><a name="giza_function_t">giza_function_t</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_function_t</td><td> (double (*funcx)(double *t), double (*funcy)(double *t), int n, double tmin, double tmax, int flag) ;</tr></table><p>Draw a curve defined by x = func(t), y = func(t), where funcx(t) and funcy(t) are user-supplied routines with a single double argument passed by reference, e.g. double myfuncx(double* t) double myfuncy(double* t)</p>
+<tr><td width=10%>void</td><td width=20%>giza_function_t</td><td> (double (*funcx)(double *t), double (*funcy)(double *t), int n, double tmin, double tmax, int flag) ;</td></tr></table><p>Draw a curve defined by x = func(t), y = func(t), where funcx(t) and funcy(t) are user-supplied routines with a single double argument passed by reference, e.g. double myfuncx(double* t) double myfuncy(double* t)</p>
 <h4>Input:</h4>
 <table class="api"><tr>
 <td>funcx  :</td><td>The parametrisation of the x value.</td>
@@ -732,10 +782,10 @@
 <td>tmax   :</td><td>The upper bound on the domain of t.</td>
 </tr></table><h3><a name="giza_function_t_float">giza_function_t_float</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_function_t_float</td><td> (float (*funcx)(float *t), float (*funcy)(float *t), int n, float tmin, float tmax, int flag) ;</tr></table><p>The same functionality as giza_function_t but uses floats. Draw a curve defined by x = func(y), where func(y) is a user-supplied routine with a single float argument passed by reference, e.g. float myfuncx(float* t) float myfuncy(float* t)</p>
+<tr><td width=10%>void</td><td width=20%>giza_function_t_float</td><td> (float (*funcx)(float *t), float (*funcy)(float *t), int n, float tmin, float tmax, int flag) ;</td></tr></table><p>The same functionality as giza_function_t but uses floats. Draw a curve defined by x = func(y), where func(y) is a user-supplied routine with a single float argument passed by reference, e.g. float myfuncx(float* t) float myfuncy(float* t)</p>
 <h4>See Also:</h4><p><a href="#giza_function_t">giza_function_t</a> </p><h3><a name="giza_function_x">giza_function_x</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_function_x</td><td> (double (*func)(double *x), int n, double xmin, double xmax, int flag) ;</tr></table><p>Draw a curve defined by y = func(x), where func(x) is a user-supplied routine with a single double argument, e.g. double myfunc(double* x)</p>
+<tr><td width=10%>void</td><td width=20%>giza_function_x</td><td> (double (*func)(double *x), int n, double xmin, double xmax, int flag) ;</td></tr></table><p>Draw a curve defined by y = func(x), where func(x) is a user-supplied routine with a single double argument, e.g. double myfunc(double* x)</p>
 <h4>Input:</h4>
 <table class="api"><tr>
 <td>func  :</td><td>The function describing y's dependence on x.</td>
@@ -747,10 +797,10 @@
 <td>xmax  :</td><td>The upper bound on the domain of x.</td>
 </tr></table><h3><a name="giza_function_x_float">giza_function_x_float</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_function_x_float</td><td> (float (*func)(float *x), int n, float xmin, float xmax, int flag) ;</tr></table><p>Same functionality as giza_function_x but takes floats. Draw a curve defined by y = func(x), where func(x) is a user-supplied routine with a single double argument, e.g. float myfunc(float* x)</p>
+<tr><td width=10%>void</td><td width=20%>giza_function_x_float</td><td> (float (*func)(float *x), int n, float xmin, float xmax, int flag) ;</td></tr></table><p>Same functionality as giza_function_x but takes floats. Draw a curve defined by y = func(x), where func(x) is a user-supplied routine with a single double argument, e.g. float myfunc(float* x)</p>
 <h4>See Also:</h4><p><a href="#giza_function_x">giza_function_x</a> </p><h3><a name="giza_line">giza_line</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_line</td><td> (int n, const double *xpts, const double *ypts) ;</tr></table><p>Plots a line made up of n-1 straight segments.</p>
+<tr><td width=10%>void</td><td width=20%>giza_line</td><td> (int n, const double *xpts, const double *ypts) ;</td></tr></table><p>Plots a line made up of n-1 straight segments.</p>
 <h4>Input:</h4>
 <table class="api"><tr>
 <td>n    :</td><td>The number of points that define the line. The line will be made up of n - 1 straight segments. If n is less than 2 nothing is done.</td>
@@ -760,10 +810,10 @@
 <td>ypts :</td><td>The world y-coordinates of the points to be joined.</td>
 </tr></table><h3><a name="giza_line_float">giza_line_float</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_line_float</td><td> (int n, const float *xpts, const float *ypts) ;</tr></table><p>The same functionality as giza_line, except it uses arrays of floats</p>
+<tr><td width=10%>void</td><td width=20%>giza_line_float</td><td> (int n, const float *xpts, const float *ypts) ;</td></tr></table><p>The same functionality as giza_line, except it uses arrays of floats</p>
 <h4>See Also:</h4><p><a href="#giza_line">giza_line</a> </p><h3><a name="giza_move">giza_move</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_move</td><td> (double xpt, double ypt) ;</tr></table><p>Move current pen position to a point</p>
+<tr><td width=10%>void</td><td width=20%>giza_move</td><td> (double xpt, double ypt) ;</td></tr></table><p>Move current pen position to a point</p>
 <h4>Input:</h4>
 <table class="api"><tr>
 <td>xpt :</td><td>The world x-coordinates of the point</td>
@@ -771,10 +821,10 @@
 <td>ypt :</td><td>The world y-coordinates of the point</td>
 </tr></table><h3><a name="giza_move_float">giza_move_float</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_move_float</td><td> (float xpt, float ypt) ;</tr></table><p>The same functionality as giza_move, except it uses floats</p>
+<tr><td width=10%>void</td><td width=20%>giza_move_float</td><td> (float xpt, float ypt) ;</td></tr></table><p>The same functionality as giza_move, except it uses floats</p>
 <h4>See Also:</h4><p><a href="#giza_move">giza_move</a> </p><h3><a name="giza_get_current_point">giza_get_current_point</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_get_current_point</td><td> (double *xpt, double *ypt) ;</tr></table><p>Query current pen position</p>
+<tr><td width=10%>void</td><td width=20%>giza_get_current_point</td><td> (double *xpt, double *ypt) ;</td></tr></table><p>Query current pen position</p>
 <h4>Output:</h4>
 <table class="api"><tr>
 <td>xpt :</td><td>The world x-coordinates of the point</td>
@@ -782,10 +832,10 @@
 <td>ypt :</td><td>The world y-coordinates of the point</td>
 </tr></table><h4>See Also:</h4><p><a href="#giza_get_current_point_float">giza_get_current_point_float</a> </p><h3><a name="giza_get_current_point_float">giza_get_current_point_float</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_get_current_point_float</td><td> (float *xpt, float *ypt) ;</tr></table><p>The same functionality as giza_get_current_point, but uses floats</p>
+<tr><td width=10%>void</td><td width=20%>giza_get_current_point_float</td><td> (float *xpt, float *ypt) ;</td></tr></table><p>The same functionality as giza_get_current_point, but uses floats</p>
 <h4>See Also:</h4><p><a href="#giza_get_current_point">giza_get_current_point</a> </p><h3><a name="giza_points">giza_points</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_points</td><td> (int n, const double* x, const double* y, int symbol) ;</tr></table><p>Plot n points at x[n], y[n] in world coords.</p>
+<tr><td width=10%>void</td><td width=20%>giza_points</td><td> (int n, const double* x, const double* y, int symbol) ;</td></tr></table><p>Plot n points at x[n], y[n] in world coords.</p>
 <h4>Input:</h4>
 <table class="api"><tr>
 <td>n      :</td><td>the number of points</td>
@@ -811,13 +861,13 @@
 </tr><tr>
 <td>5       :</td><td>x</td>
 </tr><tr>
-<td>>31    :</td><td>from the Unicode table</td>
+<td>&gt;31    :</td><td>from the Unicode table</td>
 </tr></table><h3><a name="giza_points_float">giza_points_float</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_points_float</td><td> (int n, const float* x, const float* y, int symbol) ;</tr></table><p>Same functionality as giza_points but takes floats.</p>
+<tr><td width=10%>void</td><td width=20%>giza_points_float</td><td> (int n, const float* x, const float* y, int symbol) ;</td></tr></table><p>Same functionality as giza_points but takes floats.</p>
 <h4>See Also:</h4><p><a href="#giza_points">giza_points</a> </p><h3><a name="giza_single_point">giza_single_point</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_single_point</td><td> (double x, double y, int symbol) ;</tr></table><p>Plots a single point at x, y in world coords.</p>
+<tr><td width=10%>void</td><td width=20%>giza_single_point</td><td> (double x, double y, int symbol) ;</td></tr></table><p>Plots a single point at x, y in world coords.</p>
 <h4>Input:</h4>
 <table class="api"><tr>
 <td>x      :</td><td>the x-coordinate of the point in world coords</td>
@@ -827,10 +877,10 @@
 <td>symbol :</td><td>the type of marker to use</td>
 </tr></table><h3><a name="giza_single_point_float">giza_single_point_float</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_single_point_float</td><td> (float x, float y, int symbol) ;</tr></table><p>Same functionality as giza_single_point, but uses floats.</p>
+<tr><td width=10%>void</td><td width=20%>giza_single_point_float</td><td> (float x, float y, int symbol) ;</td></tr></table><p>Same functionality as giza_single_point, but uses floats.</p>
 <h4>See Also:</h4><p><a href="#giza_single_point">giza_single_point</a> </p><h3><a name="giza_polygon">giza_polygon</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_polygon</td><td> (int n, const double *xpts, const double *ypts) ;</tr></table><p>Draws a polygon, using the current fill set by giza_set_fill.</p>
+<tr><td width=10%>void</td><td width=20%>giza_polygon</td><td> (int n, const double *xpts, const double *ypts) ;</td></tr></table><p>Draws a polygon, using the current fill set by giza_set_fill.</p>
 <h4>Input:</h4>
 <table class="api"><tr>
 <td>n       :</td><td>number of vertices</td>
@@ -840,10 +890,10 @@
 <td>ypts    :</td><td>y positions of vertices</td>
 </tr></table><h4>See Also:</h4><p><a href="#giza_set_fill">giza_set_fill</a> </p><h3><a name="giza_polygon_float">giza_polygon_float</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_polygon_float</td><td> (int n, const float *xpts, const float *ypts) ;</tr></table><p>Same functionality as giza_polygon, but takes floats</p>
+<tr><td width=10%>void</td><td width=20%>giza_polygon_float</td><td> (int n, const float *xpts, const float *ypts) ;</td></tr></table><p>Same functionality as giza_polygon, but takes floats</p>
 <h4>See Also:</h4><p><a href="#giza_polygon">giza_polygon</a> </p><h3><a name="giza_rectangle">giza_rectangle</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_rectangle</td><td> (double x1, double x2, double y1, double y2) ;</tr></table><p>Draws a rectangle with corners ((x1, y1) (x2, y1) (x2, y2) (x1, y2)), using the current fill set by giza_set_fill.</p>
+<tr><td width=10%>void</td><td width=20%>giza_rectangle</td><td> (double x1, double x2, double y1, double y2) ;</td></tr></table><p>Draws a rectangle with corners ((x1, y1) (x2, y1) (x2, y2) (x1, y2)), using the current fill set by giza_set_fill.</p>
 <h4>Inputs:</h4>
 <table class="api"><tr>
 <td>x1  :</td><td>the x-coordinate of two of the points</td>
@@ -855,10 +905,10 @@
 <td>y2  :</td><td>the y-coordinate of the other two points</td>
 </tr></table><h4>See Also:</h4><p><a href="#giza_set_fill">giza_set_fill</a> <a href="#giza_polygon">giza_polygon</a> </p><h3><a name="giza_rectangle_float">giza_rectangle_float</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_rectangle_float</td><td> (float x1, float x2, float y1, float y2) ;</tr></table><p>Same functionality as giza_rectangle but takes floats</p>
+<tr><td width=10%>void</td><td width=20%>giza_rectangle_float</td><td> (float x1, float x2, float y1, float y2) ;</td></tr></table><p>Same functionality as giza_rectangle but takes floats</p>
 <h4>See Also:</h4><p><a href="#giza_rectangle">giza_rectangle</a> </p><h3><a name="giza_rectangle_rounded">giza_rectangle_rounded</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_rectangle_rounded</td><td> (double x1, double x2, double y1, double y2, double radius) ;</tr></table><p>Draws a rectangle with rounded corners ((x1, y1) (x2, y1) (x2, y2) (x1, y2)),  using the current fill set by giza_set_fill.</p>
+<tr><td width=10%>void</td><td width=20%>giza_rectangle_rounded</td><td> (double x1, double x2, double y1, double y2, double radius) ;</td></tr></table><p>Draws a rectangle with rounded corners ((x1, y1) (x2, y1) (x2, y2) (x1, y2)),  using the current fill set by giza_set_fill.</p>
 <h4>Inputs:</h4>
 <table class="api"><tr>
 <td>x1  :</td><td>the x-coordinate of two of the points</td>
@@ -872,10 +922,10 @@
 <td>radius :</td><td>radius of curvature for the corners</td>
 </tr></table><h4>See Also:</h4><p><a href="#giza_rectangle">giza_rectangle</a> <a href="#giza_set_fill">giza_set_fill</a> <a href="#giza_polygon">giza_polygon</a> </p><h3><a name="giza_rectangle_rounded_float">giza_rectangle_rounded_float</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_rectangle_rounded_float</td><td> (float x1, float x2, float y1, float y2, float radius) ;</tr></table><p>Same functionality as giza_rectangle_rounded but takes floats</p>
+<tr><td width=10%>void</td><td width=20%>giza_rectangle_rounded_float</td><td> (float x1, float x2, float y1, float y2, float radius) ;</td></tr></table><p>Same functionality as giza_rectangle_rounded but takes floats</p>
 <h4>See Also:</h4><p><a href="#giza_rectangle_rounded">giza_rectangle_rounded</a> </p><h3><a name="giza_render">giza_render</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_render</td><td> (int sizex, int sizey, const double* data, int i1, int i2, int j1, int j2, double valMin, double valMax, int extend, int filter, const double *affine) ;</tr></table><p>Renders data to the device.</p>
+<tr><td width=10%>void</td><td width=20%>giza_render</td><td> (int sizex, int sizey, const double* data, int i1, int i2, int j1, int j2, double valMin, double valMax, int extend, int filter, const double *affine) ;</td></tr></table><p>Renders data to the device.</p>
 <h4>Input:</h4>
 <table class="api"><tr>
 <td>sizex         :</td><td>The dimensions of data in the x-direction</td>
@@ -925,28 +975,34 @@
 <td>5 or GIZA_FILTER_BILINEAR :</td><td>Linear interpolation in two dimensions</td>
 </tr></table><h4>See Also:</h4><p><a href="#giza_set_colour_table">giza_set_colour_table</a> </p><h3><a name="giza_render_transparent">giza_render_transparent</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_render_transparent</td><td> (int sizex, int sizey, const double* data, int i1, int i2, int j1, int j2, double valMin, double valMax, int extend, int filter, const double *affine) ;</tr></table><p>Same as giza_render, but data < valMin rendered as transparent</p>
+<tr><td width=10%>void</td><td width=20%>giza_render_transparent</td><td> (int sizex, int sizey, const double* data, int i1, int i2, int j1, int j2, double valMin, double valMax, int extend, int filter, const double *affine) ;</td></tr></table><p>Same as giza_render, but data &lt; valMin rendered as transparent</p>
 <h3><a name="giza_render_alpha">giza_render_alpha</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_render_alpha</td><td> (int sizex, int sizey, const double* data, const double* alpha, int i1, int i2, int j1, int j2, double valMin, double valMax, int extend, int filter, const double *affine) ;</tr></table><p>Same as giza_render, but uses additional array specifying transparency of each pixel</p>
+<tr><td width=10%>void</td><td width=20%>giza_render_alpha</td><td> (int sizex, int sizey, const double* data, const double* alpha, int i1, int i2, int j1, int j2, double valMin, double valMax, int extend, int filter, const double *affine) ;</td></tr></table><p>Same as giza_render, but uses additional array specifying transparency of each pixel</p>
 <h3><a name="giza_render_float">giza_render_float</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_render_float</td><td> (int sizex, int sizey, const float* data, int i1, int i2, int j1, int j2, float valMin, float valMax, int extend, int filter, const float *affine) ;</tr></table><p>Same functionality as giza_render but takes floats.</p>
+<tr><td width=10%>void</td><td width=20%>giza_render_float</td><td> (int sizex, int sizey, const float* data, int i1, int i2, int j1, int j2, float valMin, float valMax, int extend, int filter, const float *affine) ;</td></tr></table><p>Same functionality as giza_render but takes floats.</p>
 <h4>See Also:</h4><p><a href="#giza_render">giza_render</a> </p><h3><a name="giza_render_transparent_float">giza_render_transparent_float</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_render_transparent_float</td><td> (int sizex, int sizey, const float* data, int i1, int i2, int j1, int j2, float valMin, float valMax, int extend, int filter, const float *affine) ;</tr></table><p>Same functionality as giza_render_transparent but takes floats.</p>
+<tr><td width=10%>void</td><td width=20%>giza_render_transparent_float</td><td> (int sizex, int sizey, const float* data, int i1, int i2, int j1, int j2, float valMin, float valMax, int extend, int filter, const float *affine) ;</td></tr></table><p>Same functionality as giza_render_transparent but takes floats.</p>
 <h4>See Also:</h4><p><a href="#giza_render_transparent">giza_render_transparent</a> </p><h3><a name="giza_render_alpha_float">giza_render_alpha_float</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_render_alpha_float</td><td> (int sizex, int sizey, const float* data, const float* alpha, int i1, int i2, int j1, int j2, float valMin, float valMax, int extend, int filter, const float *affine) ;</tr></table><p>Same as giza_render_alpha but takes floats</p>
+<tr><td width=10%>void</td><td width=20%>giza_render_alpha_float</td><td> (int sizex, int sizey, const float* data, const float* alpha, int i1, int i2, int j1, int j2, float valMin, float valMax, int extend, int filter, const float *affine) ;</td></tr></table><p>Same as giza_render_alpha but takes floats</p>
 <h4>See Also:</h4><p><a href="#giza_render_alpha">giza_render_alpha</a> </p><h3><a name="giza_render_gray">giza_render_gray</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_render_gray</td><td> (int sizex, int sizey, const double* data, int i1, int i2, int j1, int j2, double valMin, double valMax, int extend, int filter, const double *affine) ;</tr></table><p>Same functionality as giza_render but renders in grayscale</p>
+<tr><td width=10%>void</td><td width=20%>giza_render_gray</td><td> (int sizex, int sizey, const double* data, int i1, int i2, int j1, int j2, double valMin, double valMax, int extend, int filter, const double *affine) ;</td></tr></table><p>Same functionality as giza_render but renders in grayscale</p>
 <h4>See Also:</h4><p><a href="#giza_render">giza_render</a> </p><h3><a name="giza_render_gray_float">giza_render_gray_float</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_render_gray_float</td><td> (int sizex, int sizey, const float* data, int i1, int i2, int j1, int j2, float valMin, float valMax, int extend, int filter, const float *affine) ;</tr></table><p>Same functionality as giza_render_gray but renders in grayscale</p>
-<h4>See Also:</h4><p><a href="#giza_render_gray">giza_render_gray</a> <a href="#giza_render">giza_render</a> </p><h3><a name="giza_draw_pixels">giza_draw_pixels</a><hr></h3>
+<tr><td width=10%>void</td><td width=20%>giza_render_gray_float</td><td> (int sizex, int sizey, const float* data, int i1, int i2, int j1, int j2, float valMin, float valMax, int extend, int filter, const float *affine) ;</td></tr></table><p>Same functionality as giza_render_gray but renders in grayscale</p>
+<h4>See Also:</h4><p><a href="#giza_render_gray">giza_render_gray</a> <a href="#giza_render">giza_render</a> </p><h3><a name="giza_render_gray_shade">giza_render_gray_shade</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_draw_pixels</td><td> (int sizex, int sizey, const int* idata, int i1, int i2, int j1, int j2, double xmin, double xmax, double ymin, double ymax, int extend, int filter) ;</tr></table><p>Renders an array of pixels according to a colour index defined for each pixel</p>
+<tr><td width=10%>void</td><td width=20%>giza_render_gray_shade</td><td> (int sizex, int sizey, const double* data, int i1, int i2, int j1, int j2, double fg, double bg, int extend, int filter, const double *affine) ;</td></tr></table><p>Greyscale image with explicit foreground and background data levels. BG maps to the dark end of the ramp, FG to the light end. When FG &lt; BG the grey ramp is reversed automatically.</p>
+<h4>See Also:</h4><p><a href="#giza_render_gray">giza_render_gray</a> <a href="#giza_render_gray_shade_float">giza_render_gray_shade_float</a> </p><h3><a name="giza_render_gray_shade_float">giza_render_gray_shade_float</a><hr></h3>
+<table class="proto">
+<tr><td width=10%>void</td><td width=20%>giza_render_gray_shade_float</td><td> (int sizex, int sizey, const float* data, int i1, int i2, int j1, int j2, float fg, float bg, int extend, int filter, const float *affine) ;</td></tr></table><p>Same as giza_render_gray_shade but with float data</p>
+<h4>See Also:</h4><p><a href="#giza_render_gray_shade">giza_render_gray_shade</a> </p><h3><a name="giza_draw_pixels">giza_draw_pixels</a><hr></h3>
+<table class="proto">
+<tr><td width=10%>void</td><td width=20%>giza_draw_pixels</td><td> (int sizex, int sizey, const int* idata, int i1, int i2, int j1, int j2, double xmin, double xmax, double ymin, double ymax, int extend, int filter) ;</td></tr></table><p>Renders an array of pixels according to a colour index defined for each pixel</p>
 <h4>Input:</h4>
 <table class="api"><tr>
 <td>sizex         :</td><td>The dimensions of data in the x-direction</td>
@@ -976,10 +1032,10 @@
 <td>filter      :</td><td>Option for how to interpolate between pixels (see giza_render, since v1.5)</td>
 </tr></table><h4>See Also:</h4><p><a href="#giza_render">giza_render</a> <a href="#giza_draw_pixels_float">giza_draw_pixels_float</a> </p><h3><a name="giza_draw_pixels_float">giza_draw_pixels_float</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_draw_pixels_float</td><td> (int sizex, int sizey, const int* idata, int i1, int i2, int j1, int j2, float xmin, float xmax, float ymin, float ymax, int extend, int filter) ;</tr></table><p>Same as giza_draw_pixels, but takes floats</p>
+<tr><td width=10%>void</td><td width=20%>giza_draw_pixels_float</td><td> (int sizex, int sizey, const int* idata, int i1, int i2, int j1, int j2, float xmin, float xmax, float ymin, float ymax, int extend, int filter) ;</td></tr></table><p>Same as giza_draw_pixels, but takes floats</p>
 <h4>See Also:</h4><p><a href="#giza_draw_pixels">giza_draw_pixels</a> </p><h3><a name="giza_tick">giza_tick</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_tick</td><td> (double x1, double y1, double x2, double y2, double v, double tickl, double tickr, double disp, double angle, const char *label) ;</tr></table><p>Draw a single tick along an axis. The axis extends from (x1,y1) to (x2,y2) and the tick is drawn perpendicular to the axis which is not drawn by this routine. Optional text label drawn parallel to the axis if the orientation angle is zero</p>
+<tr><td width=10%>void</td><td width=20%>giza_tick</td><td> (double x1, double y1, double x2, double y2, double v, double tickl, double tickr, double disp, double angle, const char *label) ;</td></tr></table><p>Draw a single tick along an axis. The axis extends from (x1,y1) to (x2,y2) and the tick is drawn perpendicular to the axis which is not drawn by this routine. Optional text label drawn parallel to the axis if the orientation angle is zero</p>
 <h4>Input:</h4>
 <table class="api"><tr>
 <td>x1   :</td><td>starting x position in world coordinates</td>
@@ -1003,10 +1059,10 @@
 <td>label :</td><td>Text string used for label (can be blank)</td>
 </tr></table><h3><a name="giza_tick_float">giza_tick_float</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_tick_float</td><td> (float x1, float y1, float x2, float y2, float v, float tickl, float tickr, float disp, float angle, const char *label) ;</tr></table><p>Same functionality as giza_tick but takes floats instead of doubles.</p>
+<tr><td width=10%>void</td><td width=20%>giza_tick_float</td><td> (float x1, float y1, float x2, float y2, float v, float tickl, float tickr, float disp, float angle, const char *label) ;</td></tr></table><p>Same functionality as giza_tick but takes floats instead of doubles.</p>
 <h4>See Also:</h4><p><a href="#giza_tick">giza_tick</a> </p><h3><a name="giza_vector">giza_vector</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_vector</td><td> (int n, int m, const double* horizontal, const double* vertical, int i1, int i2, int j1, int j2, double scale, int position, const double* affine, double blank) ;</tr></table><p>Plot of vector data.</p>
+<tr><td width=10%>void</td><td width=20%>giza_vector</td><td> (int n, int m, const double* horizontal, const double* vertical, int i1, int i2, int j1, int j2, double scale, int position, const double* affine, double blank) ;</td></tr></table><p>Plot of vector data.</p>
 <h4>Input:</h4>
 <table class="api"><tr>
 <td>n             :</td><td>The dimensions of data in the x-direction</td>
@@ -1032,11 +1088,11 @@
 <td>affine        :</td><td>The affine transformation matrix that will be applied to the data.</td>
 </tr></table><h4>See Also:</h4><p><a href="#giza_vector_float">giza_vector_float</a> <a href="#giza_arrow">giza_arrow</a> <a href="#giza_set_arrow_style">giza_set_arrow_style</a> </p><h3><a name="giza_vector_float">giza_vector_float</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_vector_float</td><td> (int n, int m, const float* horizontal, const float* vertical, int i1, int i2, int j1, int j2, float scale, int position, const float* affine, float blank) ;</tr></table><p>Same as giza_vector but takes floats</p>
+<tr><td width=10%>void</td><td width=20%>giza_vector_float</td><td> (int n, int m, const float* horizontal, const float* vertical, int i1, int i2, int j1, int j2, float scale, int position, const float* affine, float blank) ;</td></tr></table><p>Same as giza_vector but takes floats</p>
 <h4>See Also:</h4><p><a href="#giza_vector">giza_vector</a> <a href="#giza_arrow">giza_arrow</a> <a href="#giza_set_arrow_style">giza_set_arrow_style</a> </p><a name="Text"></a><h1>Text</h1>
 <h3><a name="giza_annotate">giza_annotate</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_annotate</td><td> (const char *side, double displacment, double coord, double justification, const char *string) ;</tr></table><p>Writes text with a position relative to the viewport.</p>
+<tr><td width=10%>void</td><td width=20%>giza_annotate</td><td> (const char *side, double displacment, double coord, double justification, const char *string) ;</td></tr></table><p>Writes text with a position relative to the viewport.</p>
 <h4>Input:</h4>
 <table class="api"><tr>
 <td>side          :</td><td>Must contain a character 'B','L','T' or 'R' specifying the bottom, left, top or right margin respectively. The position of the text will be relative to the specified side.</td>
@@ -1050,10 +1106,10 @@
 <td>string        :</td><td>The text that will be displayed.</td>
 </tr></table><h3><a name="giza_annotate_float">giza_annotate_float</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_annotate_float</td><td> (const char *side, float displacment, float coord, float justification, const char *string) ;</tr></table><p>The same functionality as giza_annotate but takes floats instead of doubles.</p>
+<tr><td width=10%>void</td><td width=20%>giza_annotate_float</td><td> (const char *side, float displacment, float coord, float justification, const char *string) ;</td></tr></table><p>The same functionality as giza_annotate but takes floats instead of doubles.</p>
 <h4>See Also:</h4><p><a href="#giza_annotate">giza_annotate</a> </p><h3><a name="giza_label">giza_label</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_label</td><td> (const char *labelx, const char *labely, const char *title) ;</tr></table><p>Labels the plot</p>
+<tr><td width=10%>void</td><td width=20%>giza_label</td><td> (const char *labelx, const char *labely, const char *title) ;</td></tr></table><p>Labels the plot</p>
 <h4>Input:</h4>
 <table class="api"><tr>
 <td>labelx :</td><td>x-axis label</td>
@@ -1063,10 +1119,10 @@
 <td>title  :</td><td>The title of the plot</td>
 </tr></table><h3><a name="giza_print_id">giza_print_id</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_print_id</td><td> (void) ;</tr></table><p>Prints user ID, date and time on the plot</p>
+<tr><td width=10%>void</td><td width=20%>giza_print_id</td><td> (void) ;</td></tr></table><p>Prints user ID, date and time on the plot</p>
 <h3><a name="giza_ptext">giza_ptext</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_ptext</td><td> (double x, double y, double angle, double just, const char *text) ;</tr></table><p>Draws text at a given position in world coords at a given angle with a given justification.</p>
+<tr><td width=10%>void</td><td width=20%>giza_ptext</td><td> (double x, double y, double angle, double just, const char *text) ;</td></tr></table><p>Draws text at a given position in world coords at a given angle with a given justification.</p>
 <h4>Input:</h4>
 <table class="api"><tr>
 <td>x     :</td><td>The x world coord.</td>
@@ -1080,10 +1136,10 @@
 <td>text  :</td><td>The text to be drawn.</td>
 </tr></table><h3><a name="giza_ptext_float">giza_ptext_float</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_ptext_float</td><td> (float x, float y, float angle, float just, const char *text) ;</tr></table><p>Same functionality as giza_ptext but uses floats.</p>
+<tr><td width=10%>void</td><td width=20%>giza_ptext_float</td><td> (float x, float y, float angle, float just, const char *text) ;</td></tr></table><p>Same functionality as giza_ptext but uses floats.</p>
 <h4>See Also:</h4><p><a href="#giza_ptext">giza_ptext</a> </p><h3><a name="giza_text">giza_text</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_text</td><td> (double x, double y, const char *text) ;</tr></table><p>Draws text at the position (x, y).</p>
+<tr><td width=10%>void</td><td width=20%>giza_text</td><td> (double x, double y, const char *text) ;</td></tr></table><p>Draws text at the position (x, y).</p>
 <h4>Input:</h4>
 <table class="api"><tr>
 <td>x    :</td><td>The x-coordinate of the bottom left corner of the text.</td>
@@ -1093,10 +1149,10 @@
 <td>text :</td><td>The text to be drawn.</td>
 </tr></table><h3><a name="giza_text_float">giza_text_float</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_text_float</td><td> (float x, float y, const char *text) ;</tr></table><p>Same functionality as giza_text but takes floats.</p>
+<tr><td width=10%>void</td><td width=20%>giza_text_float</td><td> (float x, float y, const char *text) ;</td></tr></table><p>Same functionality as giza_text but takes floats.</p>
 <h4>See Also:</h4><p><a href="#giza_text">giza_text</a> </p><h3><a name="giza_qtext">giza_qtext</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_qtext</td><td> (double x, double y, double angle, double just, const char *text, double xbox[4], double ybox[4]) ;</tr></table><p>Returns the co-ordinates of a box bounding the given string if printed by giza_ptext.</p>
+<tr><td width=10%>void</td><td width=20%>giza_qtext</td><td> (double x, double y, double angle, double just, const char *text, double xbox[4], double ybox[4]) ;</td></tr></table><p>Returns the co-ordinates of a box bounding the given string if printed by giza_ptext.</p>
 <h4>Input:</h4>
 <table class="api"><tr>
 <td>x     :</td><td>The x-coord of the text in world-coords</td>
@@ -1112,10 +1168,10 @@
 <td>ybox  :</td><td>Set to the world co-ords of the bounding box</td>
 </tr></table><h3><a name="giza_qtext_float">giza_qtext_float</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_qtext_float</td><td> (float x, float y, float angle, float just, const char *text, float xbox[4], float ybox[4]) ;</tr></table><p>Same as giza_qtext but takes floats</p>
+<tr><td width=10%>void</td><td width=20%>giza_qtext_float</td><td> (float x, float y, float angle, float just, const char *text, float xbox[4], float ybox[4]) ;</td></tr></table><p>Same as giza_qtext but takes floats</p>
 <h4>See Also:</h4><p><a href="#giza_qtext">giza_qtext</a> </p><h3><a name="giza_qtextlen">giza_qtextlen</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_qtextlen</td><td> (int units, const char *text, double *xlen, double *ylen) ;</tr></table><p>Returns the length of a string as would be printed by giza_ptext in a variety of units (added by DJP)</p>
+<tr><td width=10%>void</td><td width=20%>giza_qtextlen</td><td> (int units, const char *text, double *xlen, double *ylen) ;</td></tr></table><p>Returns the length of a string as would be printed by giza_ptext in a variety of units (added by DJP)</p>
 <h4>Input:</h4>
 <table class="api"><tr>
 <td>units  :</td><td>The units in which to return the values</td>
@@ -1127,24 +1183,24 @@
 <td>ylen   :</td><td>The length of the text in the y-direction</td>
 </tr></table><h3><a name="giza_qtextlen_float">giza_qtextlen_float</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_qtextlen_float</td><td> (int units, const char *text, float *xlen, float *ylen) ;</tr></table><p>Same functionality as giza_qtextlen but uses floats</p>
+<tr><td width=10%>void</td><td width=20%>giza_qtextlen_float</td><td> (int units, const char *text, float *xlen, float *ylen) ;</td></tr></table><p>Same functionality as giza_qtextlen but uses floats</p>
 <h4>See Also:</h4><p><a href="#giza_qtextlen">giza_qtextlen</a> </p><a name="Settings"></a><h1>Settings</h1>
 <h3><a name="giza_set_arrow_style">giza_set_arrow_style</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_set_arrow_style</td><td> (int fillStyle, double angle, double cutback) ;</tr></table><p>Sets the style of arrow head to be used for arrows drawn with giza_arrow.</p>
+<tr><td width=10%>void</td><td width=20%>giza_set_arrow_style</td><td> (int fillStyle, double angle, double cutback) ;</td></tr></table><p>Sets the style of arrow head to be used for arrows drawn with giza_arrow.</p>
 <h4>Input:</h4>
 <table class="api"><tr>
 <td>fillStyle :</td><td>Sets the fill style. See giza_set_fill</td>
 </tr><tr>
 <td>angle     :</td><td>Sets the acute angle of the arrow head. Can range from 0.0 to 90.</td>
 </tr><tr>
-<td>cutback   :</td><td>The fraction of the back of the arrow head that is cut back. 0.0 gives a triangular arrow head, 1.0 gives >.</td>
+<td>cutback   :</td><td>The fraction of the back of the arrow head that is cut back. 0.0 gives a triangular arrow head, 1.0 gives &gt;.</td>
 </tr></table><h3><a name="giza_set_arrow_style_float">giza_set_arrow_style_float</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_set_arrow_style_float</td><td> (int fillStyle, float angle, float cutback) ;</tr></table><p>Same functionality as giza_set_arrow_style but takes floats instead of doubles.</p>
+<tr><td width=10%>void</td><td width=20%>giza_set_arrow_style_float</td><td> (int fillStyle, float angle, float cutback) ;</td></tr></table><p>Same functionality as giza_set_arrow_style but takes floats instead of doubles.</p>
 <h4>See Also:</h4><p><a href="#giza_set_arrow_style">giza_set_arrow_style</a> </p><h3><a name="giza_get_arrow_style">giza_get_arrow_style</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_get_arrow_style</td><td> (int *fillStyle, double *angle, double *cutback) ;</tr></table><p>Queries the current arrow style settings, as set by giza_set_arrow_style.</p>
+<tr><td width=10%>void</td><td width=20%>giza_get_arrow_style</td><td> (int *fillStyle, double *angle, double *cutback) ;</td></tr></table><p>Queries the current arrow style settings, as set by giza_set_arrow_style.</p>
 <h4>Input:</h4>
 <table class="api"><tr>
 <td>fillStyle :</td><td>Gets set to the current fillstyle.</td>
@@ -1154,10 +1210,10 @@
 <td>cutback   :</td><td>Gets set to the current cutback.</td>
 </tr></table><h4>See Also:</h4><p><a href="#giza_set_arrow_style">giza_set_arrow_style</a> </p><h3><a name="giza_get_arrow_style_float">giza_get_arrow_style_float</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_get_arrow_style_float</td><td> (int *fillStyle, float *angle, float *cutback) ;</tr></table><p>Same functionality as giza_get_arrow_style, but takes floats instead of doubles.</p>
+<tr><td width=10%>void</td><td width=20%>giza_get_arrow_style_float</td><td> (int *fillStyle, float *angle, float *cutback) ;</td></tr></table><p>Same functionality as giza_get_arrow_style, but takes floats instead of doubles.</p>
 <h4>See Also:</h4><p><a href="#giza_get_arrow_style">giza_get_arrow_style</a> </p><h3><a name="giza_set_band_style">giza_set_band_style</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_set_band_style</td><td> (int ls, double lw) ;</tr></table><p>Sets the line style to be used by giza_band</p>
+<tr><td width=10%>void</td><td width=20%>giza_set_band_style</td><td> (int ls, double lw) ;</td></tr></table><p>Sets the line style to be used by giza_band</p>
 <h4>Input:</h4>
 <table class="api"><tr>
 <td>ls :</td><td>the line style for the band</td>
@@ -1165,7 +1221,7 @@
 <td>lw :</td><td>the width for the line</td>
 </tr></table><h4>See Also:</h4><p><a href="#giza_band">giza_band</a> <a href="#giza_get_band_style">giza_get_band_style</a> </p><h3><a name="giza_get_band_style">giza_get_band_style</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_get_band_style</td><td> (int *ls, double *lw) ;</tr></table><p>Queries the current band style settings to be used by giza_band</p>
+<tr><td width=10%>void</td><td width=20%>giza_get_band_style</td><td> (int *ls, double *lw) ;</td></tr></table><p>Queries the current band style settings to be used by giza_band</p>
 <h4>Output:</h4>
 <table class="api"><tr>
 <td>ls :</td><td>the line style for the band</td>
@@ -1173,37 +1229,37 @@
 <td>lw :</td><td>the width for the line</td>
 </tr></table><h4>See Also:</h4><p><a href="#giza_band">giza_band</a> <a href="#giza_set_band_style">giza_set_band_style</a> </p><h3><a name="giza_begin_buffer">giza_begin_buffer</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_begin_buffer</td><td> (void) ;</tr></table><p>Begins buffering</p>
+<tr><td width=10%>void</td><td width=20%>giza_begin_buffer</td><td> (void) ;</td></tr></table><p>Begins buffering</p>
 <h4>See Also:</h4><p><a href="#giza_end_buffer">giza_end_buffer</a> <a href="#giza_flush_buffer">giza_flush_buffer</a> </p><h3><a name="giza_end_buffer">giza_end_buffer</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_end_buffer</td><td> (void) ;</tr></table><p>Ends buffering</p>
+<tr><td width=10%>void</td><td width=20%>giza_end_buffer</td><td> (void) ;</td></tr></table><p>Ends buffering</p>
 <h4>See Also:</h4><p><a href="#giza_begin_buffer">giza_begin_buffer</a> <a href="#giza_flush_buffer">giza_flush_buffer</a> </p><h3><a name="giza_get_buffering">giza_get_buffering</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_get_buffering</td><td> (int *buf) ;</tr></table><p>returns whether output is currently buffered on current device</p>
+<tr><td width=10%>void</td><td width=20%>giza_get_buffering</td><td> (int *buf) ;</td></tr></table><p>returns whether output is currently buffered on current device</p>
 <h4>See Also:</h4><p><a href="#giza_begin_buffer">giza_begin_buffer</a> <a href="#giza_flush_buffer">giza_flush_buffer</a> <a href="#giza_end_buffer">giza_end_buffer</a> </p><h3><a name="giza_flush_buffer">giza_flush_buffer</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_flush_buffer</td><td> (void) ;</tr></table><p>Updates graphics display Can be used to flush the graphics buffer manually between calls to giza_begin_buffer and giza_end_buffer</p>
+<tr><td width=10%>void</td><td width=20%>giza_flush_buffer</td><td> (void) ;</td></tr></table><p>Updates graphics display Can be used to flush the graphics buffer manually between calls to giza_begin_buffer and giza_end_buffer</p>
 <h4>See Also:</h4><p><a href="#giza_begin_buffer">giza_begin_buffer</a> <a href="#giza_end_buffer">giza_end_buffer</a> </p><h3><a name="giza_set_character_height">giza_set_character_height</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_set_character_height</td><td> (double ch) ;</tr></table><p>Sets the font size in units of character height. A character height of 1.0 corresponds to 1/37th of the plotting surface height by default</p>
+<tr><td width=10%>void</td><td width=20%>giza_set_character_height</td><td> (double ch) ;</td></tr></table><p>Sets the font size in units of character height. A character height of 1.0 corresponds to 1/37th of the plotting surface height by default</p>
 <h4>Input:</h4>
 <table class="api"><tr>
 <td>ch :</td><td>the new character height</td>
 </tr></table><h3><a name="giza_set_character_height_float">giza_set_character_height_float</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_set_character_height_float</td><td> (float ch) ;</tr></table><p>Same functionality as giza_set_character_height but takes a float</p>
+<tr><td width=10%>void</td><td width=20%>giza_set_character_height_float</td><td> (float ch) ;</td></tr></table><p>Same functionality as giza_set_character_height but takes a float</p>
 <h3><a name="giza_get_character_height">giza_get_character_height</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_get_character_height</td><td> (double *ch) ;</tr></table><p>Query the character height</p>
+<tr><td width=10%>void</td><td width=20%>giza_get_character_height</td><td> (double *ch) ;</td></tr></table><p>Query the character height</p>
 <h4>Input:</h4>
 <table class="api"><tr>
 <td>ch :</td><td>gets set to the character height.</td>
 </tr></table><h3><a name="giza_get_character_height_float">giza_get_character_height_float</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_get_character_height_float</td><td> (float *ch) ;</tr></table><p>Same functionality as giza_get_character_height but takes a float.</p>
+<tr><td width=10%>void</td><td width=20%>giza_get_character_height_float</td><td> (float *ch) ;</td></tr></table><p>Same functionality as giza_get_character_height but takes a float.</p>
 <h4>See Also:</h4><p><a href="#giza_get_character_height">giza_get_character_height</a> </p><h3><a name="giza_get_character_size">giza_get_character_size</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_get_character_size</td><td> (int units, double *heightx, double *heighty) ;</tr></table><p>Returns the character size in a variety of units.</p>
+<tr><td width=10%>void</td><td width=20%>giza_get_character_size</td><td> (int units, double *heightx, double *heighty) ;</td></tr></table><p>Returns the character size in a variety of units.</p>
 <h4>Input:</h4>
 <table class="api"><tr>
 <td>units  :</td><td>select the units the result will be returned in.</td>
@@ -1227,22 +1283,22 @@
 <td>GIZA_UNITS_INCHES     :</td><td>inches Other values cause an error message and are treated as GIZA_UNITS_NORMALIZED</td>
 </tr></table><h3><a name="giza_get_character_size_float">giza_get_character_size_float</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_get_character_size_float</td><td> (int units, float *xch, float *ych) ;</tr></table><p>Same functionality as giza_get_character_size, but returns the values as floats</p>
+<tr><td width=10%>void</td><td width=20%>giza_get_character_size_float</td><td> (int units, float *xch, float *ych) ;</td></tr></table><p>Same functionality as giza_get_character_size, but returns the values as floats</p>
 <h3><a name="giza_set_colour_index">giza_set_colour_index</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_set_colour_index</td><td> (int ci) ;</tr></table><p>Sets the colour to that represented by the colour index ci. Represented colours can be changed via giza_set_colour_representation.</p>
+<tr><td width=10%>void</td><td width=20%>giza_set_colour_index</td><td> (int ci) ;</td></tr></table><p>Sets the colour to that represented by the colour index ci. Represented colours can be changed via giza_set_colour_representation.</p>
 <h4>Input:</h4>
 <table class="api"><tr>
 <td>ci :</td><td>The new colour index.</td>
 </tr></table><h3><a name="giza_get_colour_index">giza_get_colour_index</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_get_colour_index</td><td> (int *ci) ;</tr></table><p>Queries the current colour index.</p>
+<tr><td width=10%>void</td><td width=20%>giza_get_colour_index</td><td> (int *ci) ;</td></tr></table><p>Queries the current colour index.</p>
 <h4>Input:</h4>
 <table class="api"><tr>
 <td>ci :</td><td>gets set to the current colour index.</td>
 </tr></table><h3><a name="giza_set_colour_representation">giza_set_colour_representation</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_set_colour_representation</td><td> (int ci, double red, double green, double blue) ;</tr></table><p>Allows the user to set the colour represented by the given colour index.</p>
+<tr><td width=10%>void</td><td width=20%>giza_set_colour_representation</td><td> (int ci, double red, double green, double blue) ;</td></tr></table><p>Allows the user to set the colour represented by the given colour index.</p>
 <h4>Input:</h4>
 <table class="api"><tr>
 <td>ci   :</td><td>Which colour index to set.</td>
@@ -1254,10 +1310,10 @@
 <td>blue  :</td><td>The blue component of the colour (between 0 and 1).</td>
 </tr></table><h3><a name="giza_set_colour_representation_float">giza_set_colour_representation_float</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_set_colour_representation_float</td><td> (int ci, float red, float green, float blue) ;</tr></table><p>Same functionality as giza_set_colour_representation but takes floats/</p>
+<tr><td width=10%>void</td><td width=20%>giza_set_colour_representation_float</td><td> (int ci, float red, float green, float blue) ;</td></tr></table><p>Same functionality as giza_set_colour_representation but takes floats/</p>
 <h3><a name="giza_set_colour_representation_alpha">giza_set_colour_representation_alpha</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_set_colour_representation_alpha</td><td> (int ci, double red, double green, double blue, double alpha) ;</tr></table><p>Allows the user to set the colour represented by the given colour index, aswell as the alpha.</p>
+<tr><td width=10%>void</td><td width=20%>giza_set_colour_representation_alpha</td><td> (int ci, double red, double green, double blue, double alpha) ;</td></tr></table><p>Allows the user to set the colour represented by the given colour index, aswell as the alpha.</p>
 <h4>Input:</h4>
 <table class="api"><tr>
 <td>ci   :</td><td>Which colour index to set.</td>
@@ -1271,10 +1327,10 @@
 <td>alpha :</td><td>The alpha used when drawing with this colour index (between 0 and 1).</td>
 </tr></table><h3><a name="giza_set_colour_representation_alpha_float">giza_set_colour_representation_alpha_float</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_set_colour_representation_alpha_float</td><td> (int ci, float red, float green, float blue, float alpha) ;</tr></table><p>Same functionality as giza_set_colour_representation_alpha but takes floats.</p>
+<tr><td width=10%>void</td><td width=20%>giza_set_colour_representation_alpha_float</td><td> (int ci, float red, float green, float blue, float alpha) ;</td></tr></table><p>Same functionality as giza_set_colour_representation_alpha but takes floats.</p>
 <h4>See Also:</h4><p><a href="#giza_set_colour_representation_alpha">giza_set_colour_representation_alpha</a> <a href="#giza_set_colour_representation">giza_set_colour_representation</a> </p><h3><a name="giza_set_colour_representation_hls">giza_set_colour_representation_hls</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_set_colour_representation_hls</td><td> (int ci, double hue, double lightness, double saturation) ;</tr></table><p>Allows the user to set the colour represented by the given colour index This routine accepts colours in the Hue, Lightness and Saturation system.</p>
+<tr><td width=10%>void</td><td width=20%>giza_set_colour_representation_hls</td><td> (int ci, double hue, double lightness, double saturation) ;</td></tr></table><p>Allows the user to set the colour represented by the given colour index This routine accepts colours in the Hue, Lightness and Saturation system.</p>
 <h4>Input:</h4>
 <table class="api"><tr>
 <td>ci   :</td><td>Which colour index to set.</td>
@@ -1286,10 +1342,10 @@
 <td>saturation  :</td><td>The Saturation component of the colour (between 0 and 1).</td>
 </tr></table><h3><a name="giza_set_colour_representation_hls_float">giza_set_colour_representation_hls_float</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_set_colour_representation_hls_float</td><td> (int ci, float hue, float lightness, float saturation) ;</tr></table><p>Same functionality as giza_set_colour_representation_hls but takes floats</p>
+<tr><td width=10%>void</td><td width=20%>giza_set_colour_representation_hls_float</td><td> (int ci, float hue, float lightness, float saturation) ;</td></tr></table><p>Same functionality as giza_set_colour_representation_hls but takes floats</p>
 <h3><a name="giza_set_colour_representation_rgb">giza_set_colour_representation_rgb</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_set_colour_representation_rgb</td><td> (int ci, int red, int green, int blue) ;</tr></table><p>Same as giza_set_colour_representation but accepts integer 0->255 instead of double 0->1</p>
+<tr><td width=10%>void</td><td width=20%>giza_set_colour_representation_rgb</td><td> (int ci, int red, int green, int blue) ;</td></tr></table><p>Same as giza_set_colour_representation but accepts integer 0-&gt;255 instead of double 0-&gt;1</p>
 <h4>Input:</h4>
 <table class="api"><tr>
 <td>ci   :</td><td>Which colour index to set.</td>
@@ -1301,7 +1357,7 @@
 <td>blue  :</td><td>The blue component of the colour (between 0 and 255).</td>
 </tr></table><h4>See Also:</h4><p><a href="#giza_set_colour_representation">giza_set_colour_representation</a> <a href="#giza_set_colour_representation_rgba">giza_set_colour_representation_rgba</a> </p><h3><a name="giza_set_colour_representation_rgba">giza_set_colour_representation_rgba</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_set_colour_representation_rgba</td><td> (int ci, int red, int green, int blue, double alpha) ;</tr></table><p>Same as giza_set_colour_representation_alpha but accepts 0->255 instead of 0->1</p>
+<tr><td width=10%>void</td><td width=20%>giza_set_colour_representation_rgba</td><td> (int ci, int red, int green, int blue, double alpha) ;</td></tr></table><p>Same as giza_set_colour_representation_alpha but accepts 0-&gt;255 instead of 0-&gt;1</p>
 <h4>Input:</h4>
 <table class="api"><tr>
 <td>ci   :</td><td>Which colour index to set.</td>
@@ -1315,22 +1371,22 @@
 <td>alpha :</td><td>The alpha component of the colour (between 0 and 1)</td>
 </tr></table><h4>See Also:</h4><p><a href="#giza_set_colour_representation_alpha">giza_set_colour_representation_alpha</a> <a href="#giza_set_colour_representation_rgb">giza_set_colour_representation_rgb</a> </p><h3><a name="giza_set_colour_representation_rgba_float">giza_set_colour_representation_rgba_float</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_set_colour_representation_rgba_float</td><td> (int ci, int red, int green, int blue, float alpha) ;</tr></table><p>Same functionality as giza_set_colour_representation_rgba but takes floats</p>
+<tr><td width=10%>void</td><td width=20%>giza_set_colour_representation_rgba_float</td><td> (int ci, int red, int green, int blue, float alpha) ;</td></tr></table><p>Same functionality as giza_set_colour_representation_rgba but takes floats</p>
 <h4>See Also:</h4><p><a href="#giza_set_colour_representation_rgba">giza_set_colour_representation_rgba</a> <a href="#giza_set_colour_representation_alpha">giza_set_colour_representation_alpha</a> </p><h3><a name="giza_get_colour_representation">giza_get_colour_representation</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_get_colour_representation</td><td> (int ci, double *red, double *green, double *blue) ;</tr></table><p>Query the RGB at a given colour index.</p>
+<tr><td width=10%>void</td><td width=20%>giza_get_colour_representation</td><td> (int ci, double *red, double *green, double *blue) ;</td></tr></table><p>Query the RGB at a given colour index.</p>
 <h4>Input:</h4>
 <table class="api"><tr>
 <td>ci    :</td><td>The index to enquire about</td>
 </tr><tr>
-<td>red   :</td><td>Gets set to the red value at ci (range 0->1)</td>
+<td>red   :</td><td>Gets set to the red value at ci (range 0-&gt;1)</td>
 </tr><tr>
-<td>green :</td><td>Gets set to the green value at ci (range 0->1)</td>
+<td>green :</td><td>Gets set to the green value at ci (range 0-&gt;1)</td>
 </tr><tr>
-<td>blue  :</td><td>Gets set to the blue value at ci (range 0->1)</td>
+<td>blue  :</td><td>Gets set to the blue value at ci (range 0-&gt;1)</td>
 </tr></table><h3><a name="giza_get_colour_representation_alpha">giza_get_colour_representation_alpha</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_get_colour_representation_alpha</td><td> (int ci, double *red, double *green, double *blue, double *alpha) ;</tr></table><p>Query the RGB and alpha at a given colour index.</p>
+<tr><td width=10%>void</td><td width=20%>giza_get_colour_representation_alpha</td><td> (int ci, double *red, double *green, double *blue, double *alpha) ;</td></tr></table><p>Query the RGB and alpha at a given colour index.</p>
 <h4>Input:</h4>
 <table class="api"><tr>
 <td>ci    :</td><td>The index to enquire about</td>
@@ -1344,7 +1400,7 @@
 <td>alpha :</td><td>Gets set to the alpha at ci</td>
 </tr></table><h3><a name="giza_set_colour_index_range">giza_set_colour_index_range</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_set_colour_index_range</td><td> (int cimin, int cimax) ;</tr></table><p>Set the range of colour indices that are affected by giza_set_colour_table</p>
+<tr><td width=10%>void</td><td width=20%>giza_set_colour_index_range</td><td> (int cimin, int cimax) ;</td></tr></table><p>Set the range of colour indices that are affected by giza_set_colour_table</p>
 <h4>Note:</h4>
 <table class="api"></table><h4>Input:</h4>
 <table class="api"><tr>
@@ -1353,7 +1409,7 @@
 <td>cimax  :</td><td>highest colour index in range</td>
 </tr></table><h3><a name="giza_get_colour_index_range">giza_get_colour_index_range</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_get_colour_index_range</td><td> (int *cimin, int *cimax) ;</tr></table><p>Queries the current range of colour indices affected by giza_set_colour_table, as set by giza_set_colour_index_range</p>
+<tr><td width=10%>void</td><td width=20%>giza_get_colour_index_range</td><td> (int *cimin, int *cimax) ;</td></tr></table><p>Queries the current range of colour indices affected by giza_set_colour_table, as set by giza_set_colour_index_range</p>
 <h4>Output:</h4>
 <table class="api"><tr>
 <td>cimin  :</td><td>lowest colour index in range</td>
@@ -1361,10 +1417,10 @@
 <td>cimax  :</td><td>highest colour index in range</td>
 </tr></table><h3><a name="giza_set_range_as_colour_table">giza_set_range_as_colour_table</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>/*void</td><td width=20%>giza_set_range_as_colour_table</td><td> (int *cimin, int *cimax) ;</tr></table><p>Can be used in place of giza_set_colour_table to install the colour table from a predefined set of colour indices</p>
+<tr><td width=10%>/*void</td><td width=20%>giza_set_range_as_colour_table</td><td> (int *cimin, int *cimax) ;</td></tr></table><p>Can be used in place of giza_set_colour_table to install the colour table from a predefined set of colour indices</p>
 <h4>See Also:</h4><p><a href="#giza_set_colour_table">giza_set_colour_table</a> </p><h3><a name="giza_set_colour_palette">giza_set_colour_palette</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_set_colour_palette</td><td> (int palette) ;</tr></table><p>Choose between various preset colour "palettes" for the first 16 colour indices commonly used for point and line drawing. This is equivalent to using giza_set_colour_representation for each index in turn.</p>
+<tr><td width=10%>void</td><td width=20%>giza_set_colour_palette</td><td> (int palette) ;</td></tr></table><p>Choose between various preset colour "palettes" for the first 16 colour indices commonly used for point and line drawing. This is equivalent to using giza_set_colour_representation for each index in turn.</p>
 <h4>Note:</h4>
 <table class="api"></table><h4>Input:</h4>
 <table class="api"><tr>
@@ -1384,7 +1440,7 @@
 <td>7 :</td><td>graph-a-licious See Also: giza_set_colour_index, giza_set_colour_table</td>
 </tr></table><h3><a name="giza_set_colour_table">giza_set_colour_table</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>int</td><td width=20%>giza_set_colour_table</td><td> (const double *controlPoints, const double *red, const double *green, const double *blue, int n,  double contrast, double brightness) ;</tr></table><p>Sets the colour table.</p>
+<tr><td width=10%>int</td><td width=20%>giza_set_colour_table</td><td> (const double *controlPoints, const double *red, const double *green, const double *blue, int n,  double contrast, double brightness) ;</td></tr></table><p>Sets the colour table.</p>
 <h4>Input:</h4>
 <table class="api"><tr>
 <td>controlPoints :</td><td>Specifies at which fraction of the ramp the control points are placed</td>
@@ -1407,10 +1463,10 @@
 <td>1 :</td><td>An error occurred.</td>
 </tr></table><h3><a name="giza_set_colour_table_float">giza_set_colour_table_float</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>int</td><td width=20%>giza_set_colour_table_float</td><td> (const float *controlPoints, const float *red, const float *green, const float *blue, int n,  float contrast, float brightness) ;</tr></table><p>Same functionality as giza_set_colour_table but takes floats</p>
+<tr><td width=10%>int</td><td width=20%>giza_set_colour_table_float</td><td> (const float *controlPoints, const float *red, const float *green, const float *blue, int n,  float contrast, float brightness) ;</td></tr></table><p>Same functionality as giza_set_colour_table but takes floats</p>
 <h4>See Also:</h4><p><a href="#giza_set_colour_table">giza_set_colour_table</a> </p><h3><a name="giza_rgb_from_table">giza_rgb_from_table</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_rgb_from_table</td><td> (double pos, double *red, double *green, double *blue) ;</tr></table><p>Gets the rgb values from the colour table corresponding to the fraction of the table.</p>
+<tr><td width=10%>void</td><td width=20%>giza_rgb_from_table</td><td> (double pos, double *red, double *green, double *blue) ;</td></tr></table><p>Gets the rgb values from the colour table corresponding to the fraction of the table.</p>
 <h4>Input:</h4>
 <table class="api"><tr>
 <td>pos   :</td><td>The fraction along the table to retrieve the colour from. A value less then 0 is assigned the colour at zero, and above one assigned the colour at one.</td>
@@ -1422,16 +1478,16 @@
 <td>blue   :</td><td>Gets set to the blue component of the colour at pos.</td>
 </tr></table><h4>See Also:</h4><p><a href="#giza_set_colour_table">giza_set_colour_table</a> </p><h3><a name="giza_rgb_from_table_float">giza_rgb_from_table_float</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_rgb_from_table_float</td><td> (float pos, float *red, float *green, float *blue) ;</tr></table><p>Same functionality giza_rgb_from_table but takes floats</p>
+<tr><td width=10%>void</td><td width=20%>giza_rgb_from_table_float</td><td> (float pos, float *red, float *green, float *blue) ;</td></tr></table><p>Same functionality giza_rgb_from_table but takes floats</p>
 <h4>See Also:</h4><p><a href="#giza_rgb_from_table">giza_rgb_from_table</a> <a href="#giza_set_colour_table">giza_set_colour_table</a> </p><h3><a name="giza_save_colour_table">giza_save_colour_table</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void </td><td width=20%>giza_save_colour_table</td><td> (void) ;</tr></table><p>Saves the current colour table</p>
+<tr><td width=10%>void </td><td width=20%>giza_save_colour_table</td><td> (void) ;</td></tr></table><p>Saves the current colour table</p>
 <h4>See Also:</h4><p><a href="#giza_restore_colour_table">giza_restore_colour_table</a> </p><h3><a name="giza_restore_colour_table">giza_restore_colour_table</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void </td><td width=20%>giza_restore_colour_table</td><td> (void) ;</tr></table><p>Restores the colour table from a previously saved one</p>
+<tr><td width=10%>void </td><td width=20%>giza_restore_colour_table</td><td> (void) ;</td></tr></table><p>Restores the colour table from a previously saved one</p>
 <h4>See Also:</h4><p><a href="#giza_save_colour_table">giza_save_colour_table</a> </p><h3><a name="giza_set_environment">giza_set_environment</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_set_environment</td><td> (double xmin, double xmax, double ymin, double ymax, int just, int axis) ;</tr></table><p>Sets the plotting environment.</p>
+<tr><td width=10%>void</td><td width=20%>giza_set_environment</td><td> (double xmin, double xmax, double ymin, double ymax, int just, int axis) ;</td></tr></table><p>Sets the plotting environment.</p>
 <h4>Input:</h4>
 <table class="api"><tr>
 <td>xmin :</td><td>The min x value in world coords</td>
@@ -1468,10 +1524,10 @@
 <td>30  :</td><td>draw box and label X- and Y-axis logarithmically</td>
 </tr></table><h3><a name="giza_set_environment_float">giza_set_environment_float</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_set_environment_float</td><td> (float xmin, float xmax, float ymin, float ymax, int just, int axis) ;</tr></table><p>Same functionality as giza_set_environment but takes floats</p>
+<tr><td width=10%>void</td><td width=20%>giza_set_environment_float</td><td> (float xmin, float xmax, float ymin, float ymax, int just, int axis) ;</td></tr></table><p>Same functionality as giza_set_environment but takes floats</p>
 <h3><a name="giza_set_fill">giza_set_fill</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_set_fill</td><td> (int fs) ;</tr></table><p>Sets the current fill style.</p>
+<tr><td width=10%>void</td><td width=20%>giza_set_fill</td><td> (int fs) ;</td></tr></table><p>Sets the current fill style.</p>
 <h4>Input:</h4>
 <table class="api"><tr>
 <td>fs :</td><td>the new fill style</td>
@@ -1486,13 +1542,13 @@
 <td>4 or GIZA_FILL_CROSSHATCH  :</td><td>crosshatch</td>
 </tr></table><h3><a name="giza_get_fill">giza_get_fill</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_get_fill</td><td> (int *fs) ;</tr></table><p>Query the current fill style.</p>
+<tr><td width=10%>void</td><td width=20%>giza_get_fill</td><td> (int *fs) ;</td></tr></table><p>Query the current fill style.</p>
 <h4>Input:</h4>
 <table class="api"><tr>
 <td>fs :</td><td>gets set to the current fill style.</td>
 </tr></table><h3><a name="giza_set_hatching_style">giza_set_hatching_style</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_set_hatching_style</td><td> (double angle, double spacing, double phase) ;</tr></table><p>Sets the hatching style when using GIZA_FILL_HATCH</p>
+<tr><td width=10%>void</td><td width=20%>giza_set_hatching_style</td><td> (double angle, double spacing, double phase) ;</td></tr></table><p>Sets the hatching style when using GIZA_FILL_HATCH</p>
 <h4>Input:</h4>
 <table class="api"><tr>
 <td>angle   :</td><td>the angle of the hatching pattern with respect to the horizontal</td>
@@ -1502,10 +1558,10 @@
 <td>phase   :</td><td>a number between 0.0 and 1.0 specifying the offset along the horizontal axis to start the hatching lines</td>
 </tr></table><h4>See Also:</h4><p><a href="#giza_fill">giza_fill</a> <a href="#giza_get_hatching_style">giza_get_hatching_style</a> </p><h3><a name="giza_set_hatching_style_float">giza_set_hatching_style_float</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_set_hatching_style_float</td><td> (float angle, float spacing, float phase) ;</tr></table><p>Same as giza_set_hatching_style, but takes floats</p>
+<tr><td width=10%>void</td><td width=20%>giza_set_hatching_style_float</td><td> (float angle, float spacing, float phase) ;</td></tr></table><p>Same as giza_set_hatching_style, but takes floats</p>
 <h3><a name="giza_get_hatching_style">giza_get_hatching_style</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_get_hatching_style</td><td> (double *angle, double *spacing, double *phase) ;</tr></table><p>Queries the current hatching style wgen using GIZA_FILL_HATCH</p>
+<tr><td width=10%>void</td><td width=20%>giza_get_hatching_style</td><td> (double *angle, double *spacing, double *phase) ;</td></tr></table><p>Queries the current hatching style wgen using GIZA_FILL_HATCH</p>
 <h4>Output:</h4>
 <table class="api"><tr>
 <td>angle   :</td><td>the angle of the hatching pattern with respect to the horizontal</td>
@@ -1515,16 +1571,16 @@
 <td>phase   :</td><td>a number between 0.0 and 1.0 specifying the offset along the horizontal axis to start the hatching lines</td>
 </tr></table><h4>See Also:</h4><p><a href="#giza_fill">giza_fill</a> <a href="#giza_set_hatching_style">giza_set_hatching_style</a> </p><h3><a name="giza_get_hatching_style_float">giza_get_hatching_style_float</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_get_hatching_style_float</td><td> (float *angle, float *spacing, float *phase) ;</tr></table><p>Same as giza_get_hatching_style, but takes floats</p>
+<tr><td width=10%>void</td><td width=20%>giza_get_hatching_style_float</td><td> (float *angle, float *spacing, float *phase) ;</td></tr></table><p>Same as giza_get_hatching_style, but takes floats</p>
 <h3><a name="giza_begin_autolog">giza_begin_autolog</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void giza_begin_autolog (void)</td><td width=20%></td><td>;</tr></table><p>Turns on automatic logging of interactive devices This writes a png file every time the page is changed in an interactive device, with a name based on the current date/time (giza-%Y-%M-%D-%H:%M:%S.png). Logging can also be turned on by setting the GIZA_LOG environment variable.</p>
+<tr><td width=10%>void giza_begin_autolog (void)</td><td width=20%></td><td>;</td></tr></table><p>Turns on automatic logging of interactive devices This writes a png file every time the page is changed in an interactive device, with a name based on the current date/time (giza-%Y-%M-%D-%H:%M:%S.png). Logging can also be turned on by setting the GIZA_LOG environment variable.</p>
 <h4>See Also:</h4><p><a href="#giza_end_autolog">giza_end_autolog</a> </p><h3><a name="giza_end_autolog">giza_end_autolog</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void giza_end_autolog (void)</td><td width=20%></td><td>;</tr></table><p>Turns off automatic logging feature.</p>
+<tr><td width=10%>void giza_end_autolog (void)</td><td width=20%></td><td>;</td></tr></table><p>Turns off automatic logging feature.</p>
 <h4>See Also:</h4><p><a href="#giza_begin_autolog">giza_begin_autolog</a> </p><h3><a name="giza_set_line_cap">giza_set_line_cap</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_set_line_cap</td><td> (int lc) ;</tr></table><p>Sets the line cap.</p>
+<tr><td width=10%>void</td><td width=20%>giza_set_line_cap</td><td> (int lc) ;</td></tr></table><p>Sets the line cap.</p>
 <h4>Input:</h4>
 <table class="api"><tr>
 <td>lc :</td><td>An integer representing the line cap.</td>
@@ -1537,13 +1593,13 @@
 <td>2 :</td><td>square</td>
 </tr></table><h3><a name="giza_get_line_cap">giza_get_line_cap</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_get_line_cap</td><td> (int *lc) ;</tr></table><p>Gets the current line cap, as set by giza_set_line_cap.</p>
+<tr><td width=10%>void</td><td width=20%>giza_get_line_cap</td><td> (int *lc) ;</td></tr></table><p>Gets the current line cap, as set by giza_set_line_cap.</p>
 <h4>Input:</h4>
 <table class="api"><tr>
 <td>lc :</td><td>gets set to the current line cap.</td>
 </tr></table><h3><a name="giza_set_line_style">giza_set_line_style</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_set_line_style</td><td> (int ls) ;</tr></table><p>Sets the current line style.</p>
+<tr><td width=10%>void</td><td width=20%>giza_set_line_style</td><td> (int ls) ;</td></tr></table><p>Sets the current line style.</p>
 <h4>Input:</h4>
 <table class="api"><tr>
 <td>ls :</td><td>the new line style</td>
@@ -1562,64 +1618,64 @@
 <td>GIZA_LS_DASH_DOT_DOT_DOT :</td><td>dash dot dot dot</td>
 </tr></table><h3><a name="giza_get_line_style">giza_get_line_style</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_get_line_style</td><td> (int *ls) ;</tr></table><p>Query the current line style.</p>
+<tr><td width=10%>void</td><td width=20%>giza_get_line_style</td><td> (int *ls) ;</td></tr></table><p>Query the current line style.</p>
 <h4>Input:</h4>
 <table class="api"><tr>
 <td>ls :</td><td>gets set to the current line style</td>
 </tr></table><h3><a name="giza_set_line_width">giza_set_line_width</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_set_line_width</td><td> (double lw) ;</tr></table><p>Sets the line width for all subsequent drawing.</p>
+<tr><td width=10%>void</td><td width=20%>giza_set_line_width</td><td> (double lw) ;</td></tr></table><p>Sets the line width for all subsequent drawing.</p>
 <h4>Input:</h4>
 <table class="api"><tr>
 <td>lw :</td><td>The new line width. 1 is 1/4 of a millimetre.</td>
 </tr></table><h3><a name="giza_set_line_width_float">giza_set_line_width_float</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_set_line_width_float</td><td> (float lw) ;</tr></table><p>Same functionality as giza_set_line_width but uses floats</p>
+<tr><td width=10%>void</td><td width=20%>giza_set_line_width_float</td><td> (float lw) ;</td></tr></table><p>Same functionality as giza_set_line_width but uses floats</p>
 <h4>See Also:</h4><p><a href="#giza_set_line_width">giza_set_line_width</a> </p><h3><a name="giza_get_line_width">giza_get_line_width</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_get_line_width</td><td> (double *lw) ;</tr></table><p>Queries the current line width.</p>
+<tr><td width=10%>void</td><td width=20%>giza_get_line_width</td><td> (double *lw) ;</td></tr></table><p>Queries the current line width.</p>
 <h4>Input:</h4>
 <table class="api"><tr>
 <td>lw :</td><td>gets set to the current line width.</td>
 </tr></table><h3><a name="giza_start_prompting">giza_start_prompting</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_start_prompting</td><td> (void) ;</tr></table><p>Turns on prompting for current device, i.e. the user will be  prompted before a page change or a device being closed.</p>
+<tr><td width=10%>void</td><td width=20%>giza_start_prompting</td><td> (void) ;</td></tr></table><p>Turns on prompting for current device, i.e. the user will be  prompted before a page change or a device being closed.</p>
 <h4>See Also:</h4><p><a href="#giza_stop_prompting">giza_stop_prompting</a> </p><h3><a name="giza_stop_prompting">giza_stop_prompting</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_stop_prompting</td><td> (void) ;</tr></table><p>Turns off prompting, i.e. the user will not be prompted before a page change or a device being closed.</p>
+<tr><td width=10%>void</td><td width=20%>giza_stop_prompting</td><td> (void) ;</td></tr></table><p>Turns off prompting, i.e. the user will not be prompted before a page change or a device being closed.</p>
 <h4>See Also:</h4><p><a href="#giza_start_prompting">giza_start_prompting</a> </p><h3><a name="giza_save">giza_save</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_save</td><td> (void) ;</tr></table><p>Saves current plot settings</p>
+<tr><td width=10%>void</td><td width=20%>giza_save</td><td> (void) ;</td></tr></table><p>Saves current plot settings</p>
 <h4>See Also:</h4><p><a href="#giza_restore">giza_restore</a> </p><h3><a name="giza_restore">giza_restore</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_restore</td><td> (void) ;</tr></table><p>Restores plot settings stored via giza_save</p>
+<tr><td width=10%>void</td><td width=20%>giza_restore</td><td> (void) ;</td></tr></table><p>Restores plot settings stored via giza_save</p>
 <h4>See Also:</h4><p><a href="#giza_save">giza_save</a> </p><h3><a name="giza_set_font">giza_set_font</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_set_font</td><td> (const char *font) ;</tr></table><p>Sets the current font to the family specified in font, otherwise it is unchanged.</p>
+<tr><td width=10%>void</td><td width=20%>giza_set_font</td><td> (const char *font) ;</td></tr></table><p>Sets the current font to the family specified in font, otherwise it is unchanged.</p>
 <h4>Input:</h4>
 <table class="api"><tr>
 <td>font :</td><td>the font family to be used.</td>
 </tr></table><h3><a name="giza_set_font_bold">giza_set_font_bold</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_set_font_bold</td><td> (const char *font) ;</tr></table><p>Sets the current font to the family specified in font, otherwise it is unchanged.</p>
+<tr><td width=10%>void</td><td width=20%>giza_set_font_bold</td><td> (const char *font) ;</td></tr></table><p>Sets the current font to the family specified in font, otherwise it is unchanged.</p>
 <h4>Input:</h4>
 <table class="api"><tr>
 <td>font :</td><td>the font family to be used.</td>
 </tr></table><h3><a name="giza_set_font_italic">giza_set_font_italic</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_set_font_italic</td><td> (const char *font) ;</tr></table><p>Sets the current font to the family specified in font, otherwise it is unchanged.</p>
+<tr><td width=10%>void</td><td width=20%>giza_set_font_italic</td><td> (const char *font) ;</td></tr></table><p>Sets the current font to the family specified in font, otherwise it is unchanged.</p>
 <h4>Input:</h4>
 <table class="api"><tr>
 <td>font :</td><td>the font family to be used.</td>
 </tr></table><h3><a name="giza_set_font_bold_italic">giza_set_font_bold_italic</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_set_font_bold_italic</td><td> (const char *font) ;</tr></table><p>Sets the current font to the family specified in font, otherwise it is unchanged.</p>
+<tr><td width=10%>void</td><td width=20%>giza_set_font_bold_italic</td><td> (const char *font) ;</td></tr></table><p>Sets the current font to the family specified in font, otherwise it is unchanged.</p>
 <h4>Input:</h4>
 <table class="api"><tr>
 <td>font :</td><td>the font family to be used.</td>
 </tr></table><h3><a name="giza_get_font">giza_get_font</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_get_font</td><td> (char *font, int n) ;</tr></table><p>Sets the current font to the family specified in font, otherwise it is unchanged.</p>
+<tr><td width=10%>void</td><td width=20%>giza_get_font</td><td> (char *font, int n) ;</td></tr></table><p>Sets the current font to the family specified in font, otherwise it is unchanged.</p>
 <h4>Input:</h4>
 <table class="api"><tr>
 <td>font :</td><td>Gets set to the current font family</td>
@@ -1627,19 +1683,19 @@
 <td>n    :</td><td>The length of memory allocated to font</td>
 </tr></table><h4>See Also:</h4><p><a href="#giza_set_font">giza_set_font</a> </p><h3><a name="giza_set_text_background">giza_set_text_background</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_set_text_background</td><td> (int colourIndex) ;</tr></table><p>Set the colour index for the background of any text to be drawn. Use a negative value for a transparent background.</p>
+<tr><td width=10%>void</td><td width=20%>giza_set_text_background</td><td> (int colourIndex) ;</td></tr></table><p>Set the colour index for the background of any text to be drawn. Use a negative value for a transparent background.</p>
 <h4>Input:</h4>
 <table class="api"><tr>
 <td>colourIndex :</td><td>The colour index the background will be.</td>
 </tr></table><h3><a name="giza_get_text_background">giza_get_text_background</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_get_text_background</td><td> (int *colourIndex) ;</tr></table><p>Queries the current text background colour</p>
+<tr><td width=10%>void</td><td width=20%>giza_get_text_background</td><td> (int *colourIndex) ;</td></tr></table><p>Queries the current text background colour</p>
 <h4>Output:</h4>
 <table class="api"><tr>
 <td>colourIndex :</td><td>Current setting for the background text colour.</td>
 </tr></table><h3><a name="giza_version">giza_version</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_version</td><td> (int *major, int *minor, int *micro) ;</tr></table><p>Returns the giza version. Note that version information can also be obtained using the header variables GIZA_VERSION_STRING, GIZA_VERSION_MAJOR, GIZA_VERSION_MINOR and GIZA_VERSION_MICRO. These are available in the Fortran interface also.</p>
+<tr><td width=10%>void</td><td width=20%>giza_version</td><td> (int *major, int *minor, int *micro) ;</td></tr></table><p>Returns the giza version. Note that version information can also be obtained using the header variables GIZA_VERSION_STRING, GIZA_VERSION_MAJOR, GIZA_VERSION_MINOR and GIZA_VERSION_MICRO. These are available in the Fortran interface also.</p>
 <h4>Output:</h4>
 <table class="api"><tr>
 <td>major :</td><td>major version number</td>
@@ -1649,7 +1705,7 @@
 <td>micro :</td><td>micro version number</td>
 </tr></table><h3><a name="giza_set_viewport">giza_set_viewport</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_set_viewport</td><td> (double xleft, double xright, double ybottom, double ytop) ;</tr></table><p>Changes the size and position of the viewport, all arguments are in normalised device coordinates. The viewport is the region of the device that can be drawn to.</p>
+<tr><td width=10%>void</td><td width=20%>giza_set_viewport</td><td> (double xleft, double xright, double ybottom, double ytop) ;</td></tr></table><p>Changes the size and position of the viewport, all arguments are in normalised device coordinates. The viewport is the region of the device that can be drawn to.</p>
 <h4>Input:</h4>
 <table class="api"><tr>
 <td>xleft    :</td><td>The x coordinate of the left edge of the viewport</td>
@@ -1661,10 +1717,10 @@
 <td>ytop     :</td><td>The y coordinate of the top edge of the viewport</td>
 </tr></table><h3><a name="giza_set_viewport_float">giza_set_viewport_float</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_set_viewport_float</td><td> (float xleft, float xright, float ybottom, float ytop) ;</tr></table><p>Same functionality as giza_set_viewport but takes floats</p>
+<tr><td width=10%>void</td><td width=20%>giza_set_viewport_float</td><td> (float xleft, float xright, float ybottom, float ytop) ;</td></tr></table><p>Same functionality as giza_set_viewport but takes floats</p>
 <h4>See Also:</h4><p><a href="#giza_set_viewport">giza_set_viewport</a> </p><h3><a name="giza_get_viewport">giza_get_viewport</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_get_viewport</td><td> (int units, double *x1, double *x2, double *y1, double *y2) ;</tr></table><p>Returns the viewport size and position.</p>
+<tr><td width=10%>void</td><td width=20%>giza_get_viewport</td><td> (int units, double *x1, double *x2, double *y1, double *y2) ;</td></tr></table><p>Returns the viewport size and position.</p>
 <h4>Input:</h4>
 <table class="api"><tr>
 <td>units :</td><td>specify the units to return values in.</td>
@@ -1691,25 +1747,25 @@
 <td>default                    :</td><td>normalised device units</td>
 </tr></table><h3><a name="giza_get_viewport_float">giza_get_viewport_float</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_get_viewport_float</td><td> (int units, float *x1, float *x2, float *y1, float *y2) ;</tr></table><p>Same functionality as giza_get_viewport but uses floats</p>
+<tr><td width=10%>void</td><td width=20%>giza_get_viewport_float</td><td> (int units, float *x1, float *x2, float *y1, float *y2) ;</td></tr></table><p>Same functionality as giza_get_viewport but uses floats</p>
 <h4>See Also:</h4><p><a href="#giza_get_viewport">giza_get_viewport</a> </p><h3><a name="giza_set_viewport_default">giza_set_viewport_default</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_set_viewport_default</td><td> (void) ;</tr></table><p>Sets the viewport to the default settings</p>
+<tr><td width=10%>void</td><td width=20%>giza_set_viewport_default</td><td> (void) ;</td></tr></table><p>Sets the viewport to the default settings</p>
 <h4>See Also:</h4><p><a href="#giza_set_viewport">giza_set_viewport</a> </p><h3><a name="giza_set_viewport_inches">giza_set_viewport_inches</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_set_viewport_inches</td><td> (double xleftin, double xrightin, double ybottomin, double ytopin) ;</tr></table><p>Sets the viewport size in inches</p>
+<tr><td width=10%>void</td><td width=20%>giza_set_viewport_inches</td><td> (double xleftin, double xrightin, double ybottomin, double ytopin) ;</td></tr></table><p>Sets the viewport size in inches</p>
 <h4>See Also:</h4><p><a href="#giza_set_viewport">giza_set_viewport</a> </p><h3><a name="giza_set_viewport_inches_float">giza_set_viewport_inches_float</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_set_viewport_inches_float</td><td> (float xleftin, float xrightin, float ybottomin, float ytopin) ;</tr></table><p>Same as giza_set_viewport_inches but takes floats</p>
+<tr><td width=10%>void</td><td width=20%>giza_set_viewport_inches_float</td><td> (float xleftin, float xrightin, float ybottomin, float ytopin) ;</td></tr></table><p>Same as giza_set_viewport_inches but takes floats</p>
 <h4>See Also:</h4><p><a href="#giza_set_viewport_inches">giza_set_viewport_inches</a> </p><h3><a name="giza_start_warnings">giza_start_warnings</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_start_warnings</td><td> (void) ;</tr></table><p>Warnings will be printed to stderr.</p>
+<tr><td width=10%>void</td><td width=20%>giza_start_warnings</td><td> (void) ;</td></tr></table><p>Warnings will be printed to stderr.</p>
 <h4>See Also:</h4><p><a href="#giza_stop_warnings">giza_stop_warnings</a> </p><h3><a name="giza_stop_warnings">giza_stop_warnings</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_stop_warnings</td><td> (void) ;</tr></table><p>Warnings will not be printed to stderr.</p>
+<tr><td width=10%>void</td><td width=20%>giza_stop_warnings</td><td> (void) ;</td></tr></table><p>Warnings will not be printed to stderr.</p>
 <h4>See Also:</h4><p><a href="#giza_start_warnings">giza_start_warnings</a> </p><h3><a name="giza_set_window">giza_set_window</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_set_window</td><td> (double x1, double x2, double y1, double y2) ;</tr></table><p>Sets the limits of the axis.</p>
+<tr><td width=10%>void</td><td width=20%>giza_set_window</td><td> (double x1, double x2, double y1, double y2) ;</td></tr></table><p>Sets the limits of the axis.</p>
 <h4>Input:</h4>
 <table class="api"><tr>
 <td>x1 :</td><td>the lowest value of the x axis</td>
@@ -1721,10 +1777,10 @@
 <td>y2 :</td><td>the highest value of the y axis</td>
 </tr></table><h3><a name="giza_set_window_float">giza_set_window_float</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_set_window_float</td><td> (float x1, float x2, float y1, float y2) ;</tr></table><p>Same functionality as giza_set_window but uses floats.</p>
+<tr><td width=10%>void</td><td width=20%>giza_set_window_float</td><td> (float x1, float x2, float y1, float y2) ;</td></tr></table><p>Same functionality as giza_set_window but uses floats.</p>
 <h4>See Also:</h4><p><a href="#giza_set_window">giza_set_window</a> </p><h3><a name="giza_set_window_equal_scale">giza_set_window_equal_scale</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_set_window_equal_scale</td><td> (double x1, double x2, double y1, double y2) ;</tr></table><p>Sets the window so the x axis ranges from x1 to x2 and y from y1 to y2, then adjusts the view port to the largest possible size that that allows the axis have equal scales.</p>
+<tr><td width=10%>void</td><td width=20%>giza_set_window_equal_scale</td><td> (double x1, double x2, double y1, double y2) ;</td></tr></table><p>Sets the window so the x axis ranges from x1 to x2 and y from y1 to y2, then adjusts the view port to the largest possible size that that allows the axis have equal scales.</p>
 <h4>Input:</h4>
 <table class="api"><tr>
 <td>x1 :</td><td>the lowest value of the x axis</td>
@@ -1736,10 +1792,10 @@
 <td>y2 :</td><td>the highest value of the y axis</td>
 </tr></table><h3><a name="giza_set_window_equal_scale_float">giza_set_window_equal_scale_float</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_set_window_equal_scale_float</td><td> (float x1, float x2, float y1, float y2) ;</tr></table><p>Same functionality as giza_set_window_equal_scale but uses floats</p>
+<tr><td width=10%>void</td><td width=20%>giza_set_window_equal_scale_float</td><td> (float x1, float x2, float y1, float y2) ;</td></tr></table><p>Same functionality as giza_set_window_equal_scale but uses floats</p>
 <h4>See Also:</h4><p><a href="#giza_set_window_equal_scale">giza_set_window_equal_scale</a> </p><h3><a name="giza_get_window">giza_get_window</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_get_window</td><td> (double *x1, double *x2, double *y1, double *y2) ;</tr></table><p>Query the boundaries of the window in world coords</p>
+<tr><td width=10%>void</td><td width=20%>giza_get_window</td><td> (double *x1, double *x2, double *y1, double *y2) ;</td></tr></table><p>Query the boundaries of the window in world coords</p>
 <h4>Input:</h4>
 <table class="api"><tr>
 <td>x1 :</td><td>Gets set to the lowest value of the x axis</td>
@@ -1751,11 +1807,11 @@
 <td>y2 :</td><td>Gets set to the highest value of the y axis</td>
 </tr></table><h3><a name="giza_get_window_float">giza_get_window_float</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_get_window_float</td><td> (float *x1, float *x2, float *y1, float *y2) ;</tr></table><p>Same functionality as giza_get_window but uses floats</p>
+<tr><td width=10%>void</td><td width=20%>giza_get_window_float</td><td> (float *x1, float *x2, float *y1, float *y2) ;</td></tr></table><p>Same functionality as giza_get_window but uses floats</p>
 <a name="Interactive"></a><h1>Interactive</h1>
 <h3><a name="giza_band">giza_band</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>int</td><td width=20%>giza_band</td><td> (int mode, int moveCurs, double xanc, double yanc, double *x, double *y, char *ch) ;</tr></table><p>Returns the cursor position and character typed by the user relative to an anchor point</p>
+<tr><td width=10%>int</td><td width=20%>giza_band</td><td> (int mode, int moveCurs, double xanc, double yanc, double *x, double *y, char *ch) ;</td></tr></table><p>Returns the cursor position and character typed by the user relative to an anchor point</p>
 <h4>Input:</h4>
 <table class="api"><tr>
 <td>mode     :</td><td>selects the type of shape to draw during input</td>
@@ -1797,10 +1853,10 @@
 <td>8 or GIZA_BAND_CIRCLE    :</td><td>Circle centred on anchor point</td>
 </tr></table><h4>See Also:</h4><p><a href="#giza_get_key_press">giza_get_key_press</a> </p><h3><a name="giza_band_float">giza_band_float</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>int</td><td width=20%>giza_band_float</td><td> (int mode, int moveCurs, float xanc, float yanc, float *x, float *y, char *ch) ;</tr></table><p>Same functionality as giza_band, but uses floats.</p>
+<tr><td width=10%>int</td><td width=20%>giza_band_float</td><td> (int mode, int moveCurs, float xanc, float yanc, float *x, float *y, char *ch) ;</td></tr></table><p>Same functionality as giza_band, but uses floats.</p>
 <h4>See Also:</h4><p><a href="#giza_band">giza_band</a> </p><h3><a name="giza_mark_points">giza_mark_points</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_mark_points</td><td> (int maxpts, int *npts, double* xpts, double* ypts, int symbol) ;</tr></table><p>Mark a set of points using the cursor</p>
+<tr><td width=10%>void</td><td width=20%>giza_mark_points</td><td> (int maxpts, int *npts, double* xpts, double* ypts, int symbol) ;</td></tr></table><p>Mark a set of points using the cursor</p>
 <h4>Input:</h4>
 <table class="api"><tr>
 <td>maxpts   :</td><td>maximum number of points that may be accepted</td>
@@ -1815,10 +1871,10 @@
 <td>npts     :</td><td>number of points entered, should be zero on first call</td>
 </tr></table><h4>See Also:</h4><p><a href="#giza_points">giza_points</a> </p><h3><a name="giza_mark_points_float">giza_mark_points_float</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_mark_points_float</td><td> (int maxpts, int *npts, float* xpts, float* ypts, int symbol) ;</tr></table><p>Same functionality as giza_mark_points, but takes floats</p>
+<tr><td width=10%>void</td><td width=20%>giza_mark_points_float</td><td> (int maxpts, int *npts, float* xpts, float* ypts, int symbol) ;</td></tr></table><p>Same functionality as giza_mark_points, but takes floats</p>
 <h4>See Also:</h4><p><a href="#giza_mark_points">giza_mark_points</a> </p><h3><a name="giza_mark_points_ordered">giza_mark_points_ordered</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_mark_points_ordered</td><td> (int maxpts, int *npts, double* xpts, double* ypts, int symbol) ;</tr></table><p>Mark a set of points using the cursor</p>
+<tr><td width=10%>void</td><td width=20%>giza_mark_points_ordered</td><td> (int maxpts, int *npts, double* xpts, double* ypts, int symbol) ;</td></tr></table><p>Mark a set of points using the cursor</p>
 <h4>Input:</h4>
 <table class="api"><tr>
 <td>maxpts   :</td><td>maximum number of points that may be accepted</td>
@@ -1834,10 +1890,10 @@
 </tr></table><h4>Note:</h4>
 <table class="api"></table><h4>See Also:</h4><p><a href="#giza_points">giza_points</a> </p><h3><a name="giza_mark_points_ordered_float">giza_mark_points_ordered_float</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_mark_points_ordered_float</td><td> (int maxpts, int *npts, float* xpts, float* ypts, int symbol) ;</tr></table><p>Same functionality as giza_mark_points_ordered, but takes floats</p>
+<tr><td width=10%>void</td><td width=20%>giza_mark_points_ordered_float</td><td> (int maxpts, int *npts, float* xpts, float* ypts, int symbol) ;</td></tr></table><p>Same functionality as giza_mark_points_ordered, but takes floats</p>
 <h4>See Also:</h4><p><a href="#giza_mark_points">giza_mark_points</a> </p><h3><a name="giza_mark_line">giza_mark_line</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_mark_line</td><td> (int maxpts, int *npts, double* xpts, double* ypts) ;</tr></table><p>Mark a set of points using the cursor</p>
+<tr><td width=10%>void</td><td width=20%>giza_mark_line</td><td> (int maxpts, int *npts, double* xpts, double* ypts) ;</td></tr></table><p>Mark a set of points using the cursor</p>
 <h4>Input:</h4>
 <table class="api"><tr>
 <td>maxpts   :</td><td>maximum number of points that may be accepted</td>
@@ -1850,10 +1906,10 @@
 <td>npts     :</td><td>number of points entered, should be zero on first call</td>
 </tr></table><h4>See Also:</h4><p><a href="#giza_mark_points">giza_mark_points</a> </p><h3><a name="giza_mark_points_float">giza_mark_points_float</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_mark_line_float</td><td> (int maxpts, int *npts, float* xpts, float* ypts) ;</tr></table><p>Same functionality as giza_mark_line, but takes floats</p>
+<tr><td width=10%>void</td><td width=20%>giza_mark_line_float</td><td> (int maxpts, int *npts, float* xpts, float* ypts) ;</td></tr></table><p>Same functionality as giza_mark_line, but takes floats</p>
 <h4>See Also:</h4><p><a href="#giza_mark_line">giza_mark_line</a> <a href="#giza_mark_points">giza_mark_points</a> <a href="#giza_mark_line_ordered">giza_mark_line_ordered</a> </p><h3><a name="giza_mark_line_ordered">giza_mark_line_ordered</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_mark_line_ordered</td><td> (int maxpts, int *npts, double* xpts, double* ypts) ;</tr></table><p>Mark a set of points using the cursor</p>
+<tr><td width=10%>void</td><td width=20%>giza_mark_line_ordered</td><td> (int maxpts, int *npts, double* xpts, double* ypts) ;</td></tr></table><p>Mark a set of points using the cursor</p>
 <h4>Input:</h4>
 <table class="api"><tr>
 <td>maxpts   :</td><td>maximum number of points that may be accepted</td>
@@ -1867,16 +1923,16 @@
 </tr></table><h4>Note:</h4>
 <table class="api"></table><h4>See Also:</h4><p><a href="#giza_mark_line">giza_mark_line</a> <a href="#giza_mark_points">giza_mark_points</a> </p><h3><a name="giza_mark_line_ordered_float">giza_mark_line_ordered_float</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_mark_line_ordered_float</td><td> (int maxpts, int *npts, float* xpts, float* ypts) ;</tr></table><p>Same functionality as giza_mark_line_ordered, but takes floats</p>
+<tr><td width=10%>void</td><td width=20%>giza_mark_line_ordered_float</td><td> (int maxpts, int *npts, float* xpts, float* ypts) ;</td></tr></table><p>Same functionality as giza_mark_line_ordered, but takes floats</p>
 <h4>See Also:</h4><p><a href="#giza_mark_points">giza_mark_points</a> </p><h3><a name="giza_mark_line_char">giza_mark_line_char</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_mark_line_char</td><td> (int maxpts, int *npts, double* xpts, double* ypts, char *ch) ;</tr></table><p>Same functionality as giza_mark_line, but also returns last character pressed</p>
+<tr><td width=10%>void</td><td width=20%>giza_mark_line_char</td><td> (int maxpts, int *npts, double* xpts, double* ypts, char *ch) ;</td></tr></table><p>Same functionality as giza_mark_line, but also returns last character pressed</p>
 <h4>See Also:</h4><p><a href="#giza_mark_line">giza_mark_line</a> </p><h3><a name="giza_mark_points_float">giza_mark_points_float</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_mark_line_char_float</td><td> (int maxpts, int *npts, float* xpts, float* ypts, char *ch) ;</tr></table><p>Same functionality as giza_mark_line, but takes floats</p>
+<tr><td width=10%>void</td><td width=20%>giza_mark_line_char_float</td><td> (int maxpts, int *npts, float* xpts, float* ypts, char *ch) ;</td></tr></table><p>Same functionality as giza_mark_line, but takes floats</p>
 <h4>See Also:</h4><p><a href="#giza_mark_line">giza_mark_line</a> <a href="#giza_mark_points">giza_mark_points</a> <a href="#giza_mark_line_ordered">giza_mark_line_ordered</a> </p><h3><a name="giza_get_key_press">giza_get_key_press</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>int</td><td width=20%>giza_get_key_press</td><td> (double *x, double *y, char *ch) ;</tr></table><p>Returns the cursor position and key press after a key press.</p>
+<tr><td width=10%>int</td><td width=20%>giza_get_key_press</td><td> (double *x, double *y, char *ch) ;</td></tr></table><p>Returns the cursor position and key press after a key press.</p>
 <h4>Input:</h4>
 <table class="api"><tr>
 <td>x  :</td><td>Gets set to the x world coord of the cursor.</td>

--- a/docs/documentation/api.html
+++ b/docs/documentation/api.html
@@ -62,8 +62,6 @@
 <dd><a href="#giza_arrow_float">giza_arrow_float</a></dd>
 <dd><a href="#giza_axis">giza_axis</a></dd>
 <dd><a href="#giza_axis_float">giza_axis_float</a></dd>
-<dd><a href="#giza_box">giza_box</a></dd>
-<dd><a href="#giza_box_float">giza_box_float</a></dd>
 <dd><a href="#giza_box_time">giza_box_time</a></dd>
 <dd><a href="#giza_box_time_float">giza_box_time_float</a></dd>
 <dd><a href="#giza_box">giza_box</a></dd>
@@ -530,53 +528,7 @@
 </tr></table><h4>See Also:</h4><p><a href="#giza_axis_float">giza_axis_float</a> <a href="#giza_box">giza_box</a> <a href="#giza_tick">giza_tick</a> <a href="#giza_box_time">giza_box_time</a> </p><h3><a name="giza_axis_float">giza_axis_float</a><hr></h3>
 <table class="proto">
 <tr><td width=10%>void</td><td width=20%>giza_axis_float</td><td> (const char *opt, float x1, float y1, float x2, float y2, float v1, float v2, float step, int nsub, float dmajl, float dmajr, float fmin, float disp, float angle) ;</td></tr></table><p>Same functionality as giza_axis but takes floats instead of doubles.</p>
-<h4>See Also:</h4><p><a href="#giza_axis">giza_axis</a> </p><h3><a name="giza_box">giza_box</a><hr></h3>
-<table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_box</td><td> (const char *xopt, double xtick, int nxsub, const char *yopt, double ytick, int nysub) ;</td></tr></table><p>Annotates the viewport with labelled axis/frame</p>
-<h4>Input:</h4>
-<table class="api"><tr>
-<td>xopt  :</td><td>String of options for the x-axis. The options may be in any order. See below for details</td>
-</tr><tr>
-<td>xtick :</td><td>The distance, in world coordinates, between major ticks on the x-axis. If 0.0 the interval is chosen by giza_box.</td>
-</tr><tr>
-<td>nxsub :</td><td>The number of minor ticks to be placed between each major tick. If 0 the number is chosen by giza_box.</td>
-</tr><tr>
-<td>yopt  :</td><td>Similar to xopt but for the y-axis.</td>
-</tr><tr>
-<td>ytick :</td><td>Similar to xtick but for the y-axis.</td>
-</tr><tr>
-<td>nysub :</td><td>Similar to nxsub but for the y-axis.</td>
-</tr></table><h4>Options:</h4>
-<table class="api"><tr>
-<td>A :</td><td>Draw the axis.</td>
-</tr><tr>
-<td>B :</td><td>Draw the bottom or left edge of the frame.</td>
-</tr><tr>
-<td>C :</td><td>Draw the top or right edge of the frame.</td>
-</tr><tr>
-<td>T :</td><td>Draw major ticks.</td>
-</tr><tr>
-<td>S :</td><td>Draw minor ticks.</td>
-</tr><tr>
-<td>N :</td><td>Label the axis (conventional, below/left viewport)</td>
-</tr><tr>
-<td>M :</td><td>Put labels in the unconvential location (above/right viewport)</td>
-</tr><tr>
-<td>V :</td><td>Orient numeric y labels vertically (only applies to left and right axis).</td>
-</tr><tr>
-<td>G :</td><td>Draw grid lines at major intervals</td>
-</tr><tr>
-<td>M :</td><td>Write numeric labels above x-axis or to right of y-axis instead of usual position</td>
-</tr><tr>
-<td>L :</td><td>Label axis logarithmically</td>
-</tr><tr>
-<td>I :</td><td>'Invert' tick marks, draw them outside the viewport</td>
-</tr><tr>
-<td>P :</td><td>extend ("Project") major tick marks outside the box (ignored if option I is specified).</td>
-</tr></table><h3><a name="giza_box_float">giza_box_float</a><hr></h3>
-<table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_box_float</td><td> (const char *xopt, float xtick, int nxsub, const char *yopt, float ytick, int nysub) ;</td></tr></table><p>Same functionality as giza_box but takes floats instead of doubles.</p>
-<h4>See Also:</h4><p><a href="#giza_box">giza_box</a> </p><h3><a name="giza_box_time">giza_box_time</a><hr></h3>
+<h4>See Also:</h4><p><a href="#giza_axis">giza_axis</a> </p><h3><a name="giza_box_time">giza_box_time</a><hr></h3>
 <table class="proto">
 <tr><td width=10%>    void</td><td width=20%></td><td>     giza_box_time (const char *xopt, double xtick, int nxsub, const char *yopt, double ytick, int nysub) ;</td></tr></table><p>Same as giza_box, but labels axes with time-style labels i.e. DD HH MM SS as used in RA - DEC plots for Astronomy. If this option is used then giza_set_window should have been called with min/max given in seconds of time.</p>
 <h4>Input:</h4>

--- a/docs/documentation/api.html
+++ b/docs/documentation/api.html
@@ -107,6 +107,8 @@
 <dd><a href="#giza_render_alpha_float">giza_render_alpha_float</a></dd>
 <dd><a href="#giza_render_gray">giza_render_gray</a></dd>
 <dd><a href="#giza_render_gray_float">giza_render_gray_float</a></dd>
+<dd><a href="#giza_render_gray_shade">giza_render_gray_shade</a></dd>
+<dd><a href="#giza_render_gray_shade_float">giza_render_gray_shade_float</a></dd>
 <dd><a href="#giza_draw_pixels">giza_draw_pixels</a></dd>
 <dd><a href="#giza_draw_pixels_float">giza_draw_pixels_float</a></dd>
 <dd><a href="#giza_tick">giza_tick</a></dd>
@@ -630,14 +632,14 @@
 <tr><td width=10%>void</td><td width=20%>giza_get_clipping</td><td> (int *clip) ;</tr></table><p>Query whether or not clipping at edge of viewport is enabled or disabled</p>
 <h4>See Also:</h4><p><a href="#giza_move">giza_move</a> </p><h3><a name="giza_colour_bar">giza_colour_bar</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_colour_bar</td><td> (const char *side, double disp, double width,  double valMin, double valMax, const char *label) ;</tr></table><p>Draws a colour bar (wedge) using the current colour ramp</p>
+<tr><td width=10%>void</td><td width=20%>giza_colour_bar</td><td> (const char *side, double disp, double width, double valMin, double valMax, const char *label) ;</tr></table><p>Draws a colour bar (wedge) using the current colour ramp</p>
 <h4>Input:</h4>
 <table class="api"><tr>
 <td>side    :</td><td>edge of viewport to draw colour bar relative to, either 'B' (bottom), 'T' (top), 'L' (left) or 'R' (right)</td>
 </tr><tr>
 <td>disp    :</td><td>displacement of the bar in character heights from the specified edge</td>
 </tr><tr>
-<td>width   :</td><td>width of the colour bar in character heights</td>
+<td>width   :</td><td>total outward extent of the colour bar in character heights, including room for tick labels and an optional units label</td>
 </tr><tr>
 <td>valMin  :</td><td>The value in data that gets assigned the colour corresponding to zero on the colour ramp (The ramp is set by giza_set_colour_table)</td>
 </tr><tr>
@@ -646,7 +648,7 @@
 <td>label   :</td><td>Text label to annotate colour bar with</td>
 </tr></table><h4>See Also:</h4><p><a href="#giza_render">giza_render</a> <a href="#giza_colour_bar_float">giza_colour_bar_float</a> <a href="#giza_set_colour_table">giza_set_colour_table</a> </p><h3><a name="giza_colour_bar_float">giza_colour_bar_float</a><hr></h3>
 <table class="proto">
-<tr><td width=10%>void</td><td width=20%>giza_colour_bar_float</td><td> (const char *side, float disp, float width,  float valMin, float valMax, const char *label) ;</tr></table><p>Same functionality as giza_colour_bar, but takes floats</p>
+<tr><td width=10%>void</td><td width=20%>giza_colour_bar_float</td><td> (const char *side, float disp, float width, float valMin, float valMax, const char *label) ;</tr></table><p>Same functionality as giza_colour_bar, but takes floats</p>
 <h4>See Also:</h4><p><a href="#giza_colour_bar">giza_colour_bar</a> </p><h3><a name="giza_draw_background">giza_draw_background</a><hr></h3>
 <table class="proto">
 <tr><td width=10%>void</td><td width=20%>giza_draw_background</td><td> (void) ;</tr></table><p>Redraws the background of the currently open device (erase)</p>
@@ -944,7 +946,13 @@
 <h4>See Also:</h4><p><a href="#giza_render">giza_render</a> </p><h3><a name="giza_render_gray_float">giza_render_gray_float</a><hr></h3>
 <table class="proto">
 <tr><td width=10%>void</td><td width=20%>giza_render_gray_float</td><td> (int sizex, int sizey, const float* data, int i1, int i2, int j1, int j2, float valMin, float valMax, int extend, int filter, const float *affine) ;</tr></table><p>Same functionality as giza_render_gray but renders in grayscale</p>
-<h4>See Also:</h4><p><a href="#giza_render_gray">giza_render_gray</a> <a href="#giza_render">giza_render</a> </p><h3><a name="giza_draw_pixels">giza_draw_pixels</a><hr></h3>
+<h4>See Also:</h4><p><a href="#giza_render_gray">giza_render_gray</a> <a href="#giza_render">giza_render</a> </p><h3><a name="giza_render_gray_shade">giza_render_gray_shade</a><hr></h3>
+<table class="proto">
+<tr><td width=10%>void</td><td width=20%>giza_render_gray_shade</td><td> (int sizex, int sizey, const double* data, int i1, int i2, int j1, int j2, double fg, double bg, int extend, int filter, const double *affine) ;</tr></table><p>Greyscale image with explicit foreground and background data levels. BG maps to the dark end of the ramp, FG to the light end. When FG < BG the grey ramp is reversed automatically.</p>
+<h4>See Also:</h4><p><a href="#giza_render_gray">giza_render_gray</a> <a href="#giza_render_gray_shade_float">giza_render_gray_shade_float</a> </p><h3><a name="giza_render_gray_shade_float">giza_render_gray_shade_float</a><hr></h3>
+<table class="proto">
+<tr><td width=10%>void</td><td width=20%>giza_render_gray_shade_float</td><td> (int sizex, int sizey, const float* data, int i1, int i2, int j1, int j2, float fg, float bg, int extend, int filter, const float *affine) ;</tr></table><p>Same as giza_render_gray_shade but with float data</p>
+<h4>See Also:</h4><p><a href="#giza_render_gray_shade">giza_render_gray_shade</a> </p><h3><a name="giza_draw_pixels">giza_draw_pixels</a><hr></h3>
 <table class="proto">
 <tr><td width=10%>void</td><td width=20%>giza_draw_pixels</td><td> (int sizex, int sizey, const int* idata, int i1, int i2, int j1, int j2, double xmin, double xmax, double ymin, double ymax, int extend, int filter) ;</tr></table><p>Renders an array of pixels according to a colour index defined for each pixel</p>
 <h4>Input:</h4>

--- a/scripts/api.pl
+++ b/scripts/api.pl
@@ -17,6 +17,16 @@ $fh = new IO::File "> api.html";
 @Drawing = ();
 @Interactive = ();
 
+# Escape characters that would break HTML in generated text
+sub htmlEscape
+{
+  my ($s) = @_;
+  $s =~ s/&/&amp;/g;
+  $s =~ s/</&lt;/g;
+  $s =~ s/>/&gt;/g;
+  return $s;
+}
+
 # Subroutine for parsing individual comments
 sub processComment
 {
@@ -135,9 +145,9 @@ sub processComment
   # Name
   push @$File, "<h3><a name=\"$name\">$name</a><hr></h3>\n";
   # Prototype
-  push @$File, "<table class=\"proto\">\n<tr><td width=10%>" . shift (@prototype) . "</td><td width=20%>" . shift (@prototype) . "</td><td>" . shift (@prototype) . ";</tr></table>";
+  push @$File, "<table class=\"proto\">\n<tr><td width=10%>" . shift (@prototype) . "</td><td width=20%>" . shift (@prototype) . "</td><td>" . shift (@prototype) . ";</td></tr></table>";
   # Description
-  push @$File, "<p>$description</p>\n";
+  push @$File, "<p>" . htmlEscape($description) . "</p>\n";
   # Lists
   foreach $item (@lists)
   {
@@ -148,8 +158,8 @@ sub processComment
     # Table contents
     while (@$item)
     {
-      push @$File, "<tr>\n<td>" . shift (@$item) . ":</td>";
-      push @$File, "<td>" . shift (@$item) . "</td>\n</tr>";
+      push @$File, "<tr>\n<td>" . htmlEscape(shift (@$item)) . ":</td>";
+      push @$File, "<td>" . htmlEscape(shift (@$item)) . "</td>\n</tr>";
     }
     # Table postamble
     push @$File, "</table>";

--- a/src/giza-box-time.c
+++ b/src/giza-box-time.c
@@ -251,12 +251,12 @@ int _giza_npl(int nmax, int n) {
           do2 = 0;
 
       mod24  = 0;
-      if( strchr(xopt_cp, 'X') )
+      if( strchr(yopt_cp, 'X') )
           mod24 = 1;
 
-      if( strchr(xopt_cp, 'N') )
+      if( strchr(yopt_cp, 'N') )
           _giza_tbx4(dodayy, suptyp, 'Y', 1, first, Dev[id].Win.ymin, Dev[id].Win.ymax, tscaly, ytickd, do2, dopara, mod24);
-      if( strchr(xopt_cp, 'M') )
+      if( strchr(yopt_cp, 'M') )
           _giza_tbx4(dodayy, suptyp, 'Y', 0, first, Dev[id].Win.ymin, Dev[id].Win.ymax, tscaly, ytickd, do2, dopara, mod24);
   }
   free(xopt_cp);

--- a/src/giza-box.c
+++ b/src/giza-box.c
@@ -689,8 +689,8 @@ _giza_tick_intervals (double xmin, double xmax, double xinterval, int *i1,
 }
 
 /**
- * Finds the smallest 'round' number larger than x, where round is defined
- * as 1, 2 or 5 times a power of ten.
+ * Finds the smallest 'round' number not less than |x|, where round is
+ * defined as 2, 5, or 10 times a power of ten.
  *
  * Input:
  *  -x    :- The number to be rounded
@@ -720,10 +720,12 @@ giza_round (double x, int *nsub)
     ilog = ilog - 1;
   pwr = pow (10.0, ilog);
   frac = xx / pwr;
+
+  /* Inclusive comparisons; nice tick multiples are 2, 5, and 10. */
   i = 2;
-  if (frac < nice[1])
+  if (frac <= nice[1])
     i = 1;
-  if (frac < nice[0])
+  if (frac <= nice[0])
     i = 0;
   *nsub = 5;
   if (i == 0)

--- a/src/giza-box.c
+++ b/src/giza-box.c
@@ -122,6 +122,13 @@ giza_box (const char *xopt, double xtick, int nxsub,
     Win.ymax = pWin->ymin;
   }
 
+  /* World coordinates at each frame edge (user window, not sorted Win).
+   * Win is sorted ascending for tick interval math; ticks attach to these edges. */
+  double const win_x_left   = pWin->xmin;
+  double const win_x_right  = pWin->xmax;
+  double const win_y_bottom = pWin->ymin;
+  double const win_y_top    = pWin->ymax;
+
   /* set x-options */
   for (i = 0; xopt[i]; i++)
     {
@@ -330,14 +337,14 @@ giza_box (const char *xopt, double xtick, int nxsub,
               /* bottom */
               if (xdraw_bottom)
                 {
-                  cairo_move_to (Dev[id].context, xval, Win.ymin + (major ? xdraw_project : 0) * currentTickL);
-                  cairo_line_to (Dev[id].context, xval, Win.ymin - xdraw_invert * currentTickL);
+                  cairo_move_to (Dev[id].context, xval, win_y_bottom + (major ? xdraw_project : 0) * currentTickL);
+                  cairo_line_to (Dev[id].context, xval, win_y_bottom - xdraw_invert * currentTickL);
                 }
               /* grid */
               if (xdraw_grid && major)
                 {
-                  cairo_move_to (Dev[id].context, xval, Win.ymin);
-                  cairo_line_to (Dev[id].context, xval, Win.ymax);
+                  cairo_move_to (Dev[id].context, xval, win_y_bottom);
+                  cairo_line_to (Dev[id].context, xval, win_y_top);
                 }
               /* axis */
               else if (xdraw_axis)
@@ -348,8 +355,8 @@ giza_box (const char *xopt, double xtick, int nxsub,
               /* top */
               if (xdraw_top)
                 {
-                  cairo_move_to (Dev[id].context, xval, Win.ymax - (major ? xdraw_project : 0) * currentTickL);
-                  cairo_line_to (Dev[id].context, xval, Win.ymax + xdraw_invert * currentTickL);
+                  cairo_move_to (Dev[id].context, xval, win_y_top - (major ? xdraw_project : 0) * currentTickL);
+                  cairo_line_to (Dev[id].context, xval, win_y_top + xdraw_invert * currentTickL);
                 }
             }
         }
@@ -479,14 +486,14 @@ giza_box (const char *xopt, double xtick, int nxsub,
                 /* left */
               if (ydraw_left)
                 {
-                  cairo_move_to (Dev[id].context, Win.xmin + (major ? ydraw_project : 0) * currentTickL, yval);
-                  cairo_line_to (Dev[id].context, Win.xmin - ydraw_invert * currentTickL, yval);
+                  cairo_move_to (Dev[id].context, win_x_left + (major ? ydraw_project : 0) * currentTickL, yval);
+                  cairo_line_to (Dev[id].context, win_x_left - ydraw_invert * currentTickL, yval);
                 }
               /* grid */
               if (ydraw_grid && major)
                 {
-                  cairo_move_to (Dev[id].context, Win.xmin, yval);
-                  cairo_line_to (Dev[id].context, Win.xmax, yval);
+                  cairo_move_to (Dev[id].context, win_x_left, yval);
+                  cairo_line_to (Dev[id].context, win_x_right, yval);
                 }
               /* axis */
               else if (ydraw_axis)
@@ -497,8 +504,8 @@ giza_box (const char *xopt, double xtick, int nxsub,
               /* right */
               if (ydraw_right)
                 {
-                  cairo_move_to (Dev[id].context, Win.xmax - (major ? ydraw_project : 0) * currentTickL, yval);
-                  cairo_line_to (Dev[id].context, Win.xmax + ydraw_invert * currentTickL, yval);
+                  cairo_move_to (Dev[id].context, win_x_right - (major ? ydraw_project : 0) * currentTickL, yval);
+                  cairo_line_to (Dev[id].context, win_x_right + ydraw_invert * currentTickL, yval);
                 }
             }
         }

--- a/src/giza-colour-bar.c
+++ b/src/giza-colour-bar.c
@@ -26,6 +26,30 @@
 #include <giza.h>
 #include <string.h>
 
+/* Fraction of total width reserved for tick labels and units text. */
+static double const annotation_fraction = 0.6;
+
+/* Displacement of the units label from the wedge viewport edge (character heights). */
+static double const label_separation = 2.2;
+
+/* Grey ramp occupies this band on the cross-axis world window (plot-adjacent edge). */
+static double const ramp_band_inner = 0.9;
+static double const ramp_band_outer = 1.1;
+
+static int
+_giza_label_is_blank (const char *label)
+{
+  if (!label)
+    return 1;
+  while (*label)
+    {
+      if (*label != ' ' && *label != '\t')
+        return 0;
+      label++;
+    }
+  return 1;
+}
+
 /**
  * Drawing: giza_colour_bar
  *
@@ -34,7 +58,8 @@
  * Input:
  *  -side    :- edge of viewport to draw colour bar relative to, either 'B' (bottom), 'T' (top), 'L' (left) or 'R' (right)
  *  -disp    :- displacement of the bar in character heights from the specified edge
- *  -width   :- width of the colour bar in character heights
+ *  -width   :- total outward extent of the colour bar in character heights, including
+ *              room for tick labels and an optional units label
  *  -valMin  :- The value in data that gets assigned the colour corresponding to zero on the
  *              colour ramp (The ramp is set by giza_set_colour_table)
  *  -valMax  :- The value in data that gets assigned the colour corresponding to one on the
@@ -44,31 +69,32 @@
  * See Also: giza_render, giza_colour_bar_float, giza_set_colour_table
  */
 void
-giza_colour_bar (const char *side, double disp, double width, 
+giza_colour_bar (const char *side, double disp, double width,
                  double valMin, double valMax, const char *label)
 {
-  /* query current window, viewport and character height settings */
-  double xmin,xmax,ymin,ymax;
-  double vptxmin,vptxmax,vptymin,vptymax;
-  double xch,ych;
-  giza_get_window(&xmin,&xmax,&ymin,&ymax);
-  giza_get_viewport(GIZA_UNITS_NORMALIZED,&vptxmin,&vptxmax,&vptymin,&vptymax);
-  giza_get_character_size(GIZA_UNITS_NORMALIZED,&xch,&ych);
+  double xmin, xmax, ymin, ymax;
+  double vptxmin, vptxmax, vptymin, vptymax;
+  double xch, ych;
+  double old_ch, wedge_ch, label_width_ch;
+  double wedge_xmin, wedge_xmax, wedge_ymin, wedge_ymax;
+  double ch_cross, ch_along;
+  int npixwedg = 100;
+  double sample[100];
+  double vmin, vmax, dx;
+  int i;
+  int bottom = 0, top = 0, left = 0, right = 0;
+  int greyscale = 0;
+  double affine[6] = { 1.0, 0.0, 0.0, 1.0, 0.0, 0.0 };
 
-  /* setup affine matrix for call to giza_render */
-  double affine[6];
-  affine[0] = 1.0;
-  affine[1] = 0.0;
-  affine[2] = 0.0;
-  affine[3] = 1.0;
-  affine[4] = 0.0;
-  affine[5] = 0.0;
+  if (!_giza_check_device_ready ("giza_colour_bar"))
+    return;
 
-  /* fill an array with values from valMin to valMax */
-  int npixwedg = 400;
-  double sample[npixwedg];
-  double vmin,vmax;
-  if (valMax < valMin) 
+  giza_get_window (&xmin, &xmax, &ymin, &ymax);
+  giza_get_viewport (GIZA_UNITS_NORMALIZED, &vptxmin, &vptxmax, &vptymin, &vptymax);
+  giza_get_character_size (GIZA_UNITS_NORMALIZED, &xch, &ych);
+  giza_get_character_height (&old_ch);
+
+  if (valMax < valMin)
     {
       vmin = valMax;
       vmax = valMin;
@@ -78,108 +104,107 @@ giza_colour_bar (const char *side, double disp, double width,
       vmin = valMin;
       vmax = valMax;
     }
-  double dx = (vmax - vmin)/((double) (npixwedg-1));
-  
-  int i;
+
+  dx = (vmax - vmin) / ((double) (npixwedg - 1));
   for (i = 0; i < npixwedg; i++)
-     {
-        sample[i] = vmin + i*dx;
-     }
+    sample[i] = vmin + i * dx;
 
-  double vptxmini = vptxmin;
-  double vptxmaxi = vptxmax;
-  double vptymini = vptymin;
-  double vptymaxi = vptymax;
-  
-  int bottom = 0, top = 0, left = 0, right = 0;
-  if (strchr(side,'B') || strchr(side,'b'))      { bottom = 1; }
-  else if (strchr(side,'T') || strchr(side,'t')) { top = 1; }
-  else if (strchr(side,'L') || strchr(side,'l')) { left = 1; }
-  else if (strchr(side,'R') || strchr(side,'r')) { right = 1; }
-  
-  int greyscale = 0;
-  if (strchr(side,'G') || strchr(side,'g')) { greyscale = 1; }
-  
-  if (bottom || top) 
+  wedge_ch = width * (1.0 - annotation_fraction);
+  if (wedge_ch <= 0.)
+    wedge_ch = width;
+
+  label_width_ch = label_separation;
+  if (!_giza_label_is_blank (label))
+    label_width_ch += 1.0;
+
+  giza_set_character_height (annotation_fraction * width * old_ch / label_width_ch);
+
+  if (strchr (side, 'B') || strchr (side, 'b'))
+    bottom = 1;
+  else if (strchr (side, 'T') || strchr (side, 't'))
+    top = 1;
+  else if (strchr (side, 'L') || strchr (side, 'l'))
+    left = 1;
+  else if (strchr (side, 'R') || strchr (side, 'r'))
+    right = 1;
+
+  if (strchr (side, 'G') || strchr (side, 'g'))
+    greyscale = 1;
+
+  wedge_xmin = vptxmin;
+  wedge_xmax = vptxmax;
+  wedge_ymin = vptymin;
+  wedge_ymax = vptymax;
+
+  if (bottom || top)
     {
-       if (bottom)
-         { 
-           vptymaxi = vptymini - disp*ych;
-           vptymini = vptymaxi - width*xch;
-         }
-       else
-         {
-           vptymini = vptymaxi + disp*ych;
-           vptymaxi = vptymini + width*xch;         
-         }
+      ch_cross = ych;
+      ch_along = ych;
 
-       giza_set_viewport(vptxmini,vptxmaxi,vptymini,vptymaxi);
-       giza_set_window(1.0,(double) npixwedg, 0.0, 1.0);
-       if (greyscale)
-         {
-           giza_render_gray(npixwedg,1,sample,0,npixwedg-1,0,0,valMin,valMax,
-                       GIZA_EXTEND_PAD,GIZA_FILTER_DEFAULT,affine);
-         }
-       else
-         {
-           giza_render(npixwedg,1,sample,0,npixwedg-1,0,0,valMin,valMax,
-                       GIZA_EXTEND_PAD,GIZA_FILTER_DEFAULT,affine);
-         }
+      if (bottom)
+        {
+          wedge_ymax = wedge_ymin - disp * ch_along;
+          wedge_ymin = wedge_ymax - wedge_ch * ch_cross;
+        }
+      else
+        {
+          wedge_ymin = wedge_ymax + disp * ch_along;
+          wedge_ymax = wedge_ymin + wedge_ch * ch_cross;
+        }
 
-       giza_set_window(vmin,vmax,0.0,1.0);
+      giza_set_viewport (wedge_xmin, wedge_xmax, wedge_ymin, wedge_ymax);
+      giza_set_window (1.0, (double) npixwedg, ramp_band_inner, ramp_band_outer);
+      if (greyscale)
+        giza_render_gray (npixwedg, 1, sample, 0, npixwedg - 1, 0, 0, valMin, valMax,
+                         GIZA_EXTEND_PAD, GIZA_FILTER_DEFAULT, affine);
+      else
+        giza_render (npixwedg, 1, sample, 0, npixwedg - 1, 0, 0, valMin, valMax,
+                     GIZA_EXTEND_PAD, GIZA_FILTER_DEFAULT, affine);
 
-       if (bottom)
-         {
-           giza_box("BCNST",0.0,0,"BC",0.0,0);
-         }
-       else
-         {
-           giza_box("BCMST",0.0,0,"BC",0.0,0);         
-         }
+      giza_set_window (vmin, vmax, 0.0, 1.0);
+      if (bottom)
+        giza_box ("BCNST", 0.0, 0, "BC", 0.0, 0);
+      else
+        giza_box ("BCMST", 0.0, 0, "BC", 0.0, 0);
     }
   else if (left || right)
     {
-       if (left)
-         { 
-           vptxmaxi = vptxmini - disp*xch;
-           vptxmini = vptxmaxi - width*xch;
-         }
-       else
-         {
-           vptxmini = vptxmaxi + disp*xch;
-           vptxmaxi = vptxmini + width*xch;
-         }
+      ch_cross = xch;
+      ch_along = xch;
 
-       giza_set_viewport(vptxmini,vptxmaxi,vptymini,vptymaxi);
-       giza_set_window(0.0, 1.0, 1.0,(double) npixwedg);
-       if (greyscale)
-         {
-           giza_render_gray(1,npixwedg,sample,0,0,0,npixwedg-1,valMin,valMax,
-                       GIZA_EXTEND_PAD,GIZA_FILTER_DEFAULT,affine);
-         }
-       else
-         {
-           giza_render(1,npixwedg,sample,0,0,0,npixwedg-1,valMin,valMax,
-                       GIZA_EXTEND_PAD,GIZA_FILTER_DEFAULT,affine);
-         }
+      if (left)
+        {
+          wedge_xmax = wedge_xmin - disp * ch_along;
+          wedge_xmin = wedge_xmax - wedge_ch * ch_cross;
+        }
+      else
+        {
+          wedge_xmin = wedge_xmax + disp * ch_along;
+          wedge_xmax = wedge_xmin + wedge_ch * ch_cross;
+        }
 
-       giza_set_window(0.0,1.0,vmin,vmax);
+      giza_set_viewport (wedge_xmin, wedge_xmax, wedge_ymin, wedge_ymax);
+      giza_set_window (ramp_band_inner, ramp_band_outer, 1.0, (double) npixwedg);
+      if (greyscale)
+        giza_render_gray (1, npixwedg, sample, 0, 0, 0, npixwedg - 1, valMin, valMax,
+                         GIZA_EXTEND_PAD, GIZA_FILTER_DEFAULT, affine);
+      else
+        giza_render (1, npixwedg, sample, 0, 0, 0, npixwedg - 1, valMin, valMax,
+                     GIZA_EXTEND_PAD, GIZA_FILTER_DEFAULT, affine);
 
-       if (left)
-         {
-           giza_box("BC",0.0,0,"BCNST",0.0,0);
-         }
-       else
-         {
-           giza_box("BC",0.0,0,"BCMST",0.0,0);         
-         }
+      giza_set_window (0.0, 1.0, vmin, vmax);
+      if (left)
+        giza_box ("BC", 0.0, 0, "BCNST", 0.0, 0);
+      else
+        giza_box ("BC", 0.0, 0, "BCMST", 0.0, 0);
     }
 
-  giza_annotate(side,2.8,1.0,1.0,label);
+  if (!_giza_label_is_blank (label))
+    giza_annotate (side, label_separation, 1.0, 1.0, label);
 
-  /* reset window and viewport */
-  giza_set_viewport(vptxmin,vptxmax,vptymin,vptymax);
-  giza_set_window(xmin,xmax,ymin,ymax);
+  giza_set_viewport (vptxmin, vptxmax, vptymin, vptymax);
+  giza_set_window (xmin, xmax, ymin, ymax);
+  giza_set_character_height (old_ch);
 
   giza_flush_device ();
 }
@@ -192,7 +217,7 @@ giza_colour_bar (const char *side, double disp, double width,
  * See Also: giza_colour_bar
  */
 void
-giza_colour_bar_float (const char *side, float disp, float width, 
+giza_colour_bar_float (const char *side, float disp, float width,
                        float valMin, float valMax, const char *label)
 {
   giza_colour_bar (side, (double) disp, (double) width,

--- a/src/giza-colour-palette.c
+++ b/src/giza-colour-palette.c
@@ -74,6 +74,9 @@ giza_set_colour_palette (int palette)
   switch(palette)
   {
     case GIZA_COLOUR_PALETTE_PGPLOT:
+    /* Classic PGPLOT: index 0 = background (black), 1 = foreground (white) */
+       giza_set_colour_representation (0,0.0,0.0,0.0);
+       giza_set_colour_representation (1,1.0,1.0,1.0);
     /* Installs the standard PGPLOT colour table */
        giza_set_colour_representation (2,1.0,0.0,0.0);
        giza_set_colour_representation (3,0.0,1.0,0.0);

--- a/src/giza-colour-table.c
+++ b/src/giza-colour-table.c
@@ -328,6 +328,18 @@ giza_set_colour_table_gray (void)
 }
 
 /**
+ * (Re)sets the colour table to a simple white->black ramp (inverted grey)
+ */
+int
+giza_set_colour_table_gray_inverted (void)
+{
+  double cp[2], r[2], g[2], b[2];
+  cp[0] = 0.; r[0] = 0.; g[0] = 0.; b[0] = 0.;
+  cp[1] = 1.; r[1] = 1.; g[1] = 1.; b[1] = 1.;
+  return giza_set_colour_table (cp, r, g, b, 2, -1., 0.5);
+}
+
+/**
  * Sets rgb colours for the colour indices in the given range
  * as a linear ramp based on the current giza colour table
  */

--- a/src/giza-colour-table.c
+++ b/src/giza-colour-table.c
@@ -328,18 +328,6 @@ giza_set_colour_table_gray (void)
 }
 
 /**
- * (Re)sets the colour table to a simple white->black ramp (inverted grey)
- */
-int
-giza_set_colour_table_gray_inverted (void)
-{
-  double cp[2], r[2], g[2], b[2];
-  cp[0] = 0.; r[0] = 0.; g[0] = 0.; b[0] = 0.;
-  cp[1] = 1.; r[1] = 1.; g[1] = 1.; b[1] = 1.;
-  return giza_set_colour_table (cp, r, g, b, 2, -1., 0.5);
-}
-
-/**
  * Sets rgb colours for the colour indices in the given range
  * as a linear ramp based on the current giza colour table
  */

--- a/src/giza-cpgplot.c
+++ b/src/giza-cpgplot.c
@@ -506,7 +506,7 @@ void cpggray(const float *a, int idim, int jdim, int i1, int i2, \
   affine[3] = tr[5];
   affine[4] = tr[0] + tr[1]*(i1 - 0.5f) + tr[2]*(j1 - 0.5f);
   affine[5] = tr[3] + tr[4]*(i1 - 0.5f) + tr[5]*(j1 - 0.5f);
-  giza_render_gray_float(idim,jdim,a,i1-1,i2-1,j1-1,j2-1,fg,bg, \
+  giza_render_gray_shade_float(idim,jdim,a,i1-1,i2-1,j1-1,j2-1,fg,bg, \
                          GIZA_EXTEND_NONE,GIZA_FILTER_NEAREST,affine);
 }
 
@@ -719,6 +719,11 @@ void cpgolin(int maxpt, int *npt, float *x, float *y, int symbol)
 int cpgopen(const char *device)
 {
   int pgopen = giza_open_device(device,"giza");
+  if (pgopen > 0)
+    {
+      giza_set_colour_palette(GIZA_COLOUR_PALETTE_PGPLOT);
+      giza_draw_background();
+    }
   return pgopen;
 }
 
@@ -1538,7 +1543,7 @@ void cpgvstd(void)
 void cpgwedg(const char *side, float disp, float width, \
  float fg, float bg, const char *label)
 {
-  giza_colour_bar_float(side,disp,width,fg,bg,label);
+  giza_colour_bar_float(side,disp,width,bg,fg,label);
 }
 
 /***************************************************************

--- a/src/giza-cpgplot.c
+++ b/src/giza-cpgplot.c
@@ -721,8 +721,12 @@ int cpgopen(const char *device)
   int pgopen = giza_open_device(device,"giza");
   if (pgopen > 0)
     {
+      char is_hardcopy[16];
+      int len = sizeof(is_hardcopy);
       giza_set_colour_palette(GIZA_COLOUR_PALETTE_PGPLOT);
-      giza_draw_background();
+      giza_query_device("hardcopy", is_hardcopy, &len);
+      if (strcmp(is_hardcopy, "YES") != 0)
+        giza_draw_background();
     }
   return pgopen;
 }

--- a/src/giza-fortran.F90
+++ b/src/giza-fortran.F90
@@ -126,6 +126,7 @@ module giza
       giza_rectangle, &
       giza_render, &
       giza_render_gray, &
+      giza_render_gray_shade, &
       giza_render_transparent, &
       giza_draw_pixels, &
       giza_restore, &
@@ -1533,6 +1534,26 @@ private
       real(kind=c_float),intent(in),value :: valMin,valMax
       real(kind=c_float),intent(in) :: affine(6)
     end subroutine giza_render_gray_float
+ end interface
+
+ interface giza_render_gray_shade
+    subroutine giza_render_gray_shade_double(sizex,sizey,data,i1,i2,j1,j2,&
+               fg,bg,extend,filter,affine) bind(C, name="giza_render_gray_shade")
+      import
+      integer(kind=c_int),intent(in),value :: sizex,sizey,i1,i2,j1,j2,extend,filter
+      real(kind=c_double),intent(in) :: data(sizex,sizey)
+      real(kind=c_double),intent(in),value :: fg,bg
+      real(kind=c_double),intent(in) :: affine(6)
+    end subroutine giza_render_gray_shade_double
+
+    subroutine giza_render_gray_shade_float(sizex,sizey,data,i1,i2,j1,j2,&
+               fg,bg,extend,filter,affine) bind(C, name="giza_render_gray_shade_float")
+      import
+      integer(kind=c_int),intent(in),value :: sizex,sizey,i1,i2,j1,j2,extend,filter
+      real(kind=c_float),intent(in) :: data(sizex,sizey)
+      real(kind=c_float),intent(in),value :: fg,bg
+      real(kind=c_float),intent(in) :: affine(6)
+    end subroutine giza_render_gray_shade_float
  end interface
 
  interface giza_draw_pixels

--- a/src/giza-pgplot.f90
+++ b/src/giza-pgplot.f90
@@ -677,7 +677,7 @@ end subroutine PGFUNY
 ! Status: IMPLEMENTED
 !------------------------------------------------------------------------
 subroutine PGGRAY (A, IDIM, JDIM, I1, I2, J1, J2, FG, BG, TR)
- use giza,       only:giza_render_gray,giza_extend_none,giza_filter_nearest
+ use giza,       only:giza_render_gray_shade,giza_extend_none,giza_filter_nearest
  use gizapgplot, only:convert_tr_to_affine
  implicit none
  integer, intent(in) :: IDIM, JDIM, I1, I2, J1, J2
@@ -685,7 +685,7 @@ subroutine PGGRAY (A, IDIM, JDIM, I1, I2, J1, J2, FG, BG, TR)
  real, dimension(6)  :: affine
 
  call convert_tr_to_affine(tr,affine)
- call giza_render_gray(idim,jdim,a,i1-1,i2-1,j1-1,j2-1,fg,bg,giza_extend_none,giza_filter_nearest,affine)
+ call giza_render_gray_shade(idim,jdim,a,i1-1,i2-1,j1-1,j2-1,fg,bg,giza_extend_none,giza_filter_nearest,affine)
 
 end subroutine PGGRAY
 
@@ -941,7 +941,7 @@ end subroutine PGOLIN
 ! Status: IMPLEMENTED
 !------------------------------------------------------------------------
 integer function PGOPEN (DEVICE)
- use giza, only:giza_open_device,giza_set_colour_palette,giza_colour_palette_pgplot
+ use giza, only:giza_open_device,giza_set_colour_palette,giza_colour_palette_pgplot,giza_draw_background
 ! use giza, only:giza_open_device_size,giza_units_mm,giza_units_inches
  implicit none
  character*(*), intent(in) :: DEVICE
@@ -951,6 +951,7 @@ integer function PGOPEN (DEVICE)
  pgopen = giza_open_device(device,'giza')
 
  call giza_set_colour_palette(giza_colour_palette_pgplot)
+ call giza_draw_background()
 
 end function PGOPEN
 
@@ -2018,7 +2019,7 @@ subroutine PGWEDG(SIDE, DISP, WIDTH, FG, BG, LABEL)
  character *(*), intent(in) :: SIDE,LABEL
  real,           intent(in) :: DISP, WIDTH, FG, BG
 
- call giza_colour_bar(SIDE, DISP, WIDTH, FG, BG, LABEL)
+ call giza_colour_bar(SIDE, DISP, WIDTH, BG, FG, LABEL)
 
 end subroutine PGWEDG
 

--- a/src/giza-pgplot.f90
+++ b/src/giza-pgplot.f90
@@ -941,17 +941,23 @@ end subroutine PGOLIN
 ! Status: IMPLEMENTED
 !------------------------------------------------------------------------
 integer function PGOPEN (DEVICE)
- use giza, only:giza_open_device,giza_set_colour_palette,giza_colour_palette_pgplot,giza_draw_background
+ use giza, only:giza_open_device,giza_set_colour_palette,giza_colour_palette_pgplot,giza_draw_background,giza_query_device
 ! use giza, only:giza_open_device_size,giza_units_mm,giza_units_inches
  implicit none
  character*(*), intent(in) :: DEVICE
+ character(len=16) :: is_hardcopy
 
 ! print*,'giza units mm = ',giza_units_mm
 ! pgopen = giza_open_device_size(device,'giza',11.0,8.5,giza_units_inches)
  pgopen = giza_open_device(device,'giza')
 
- call giza_set_colour_palette(giza_colour_palette_pgplot)
- call giza_draw_background()
+ if (pgopen > 0) then
+    call giza_set_colour_palette(giza_colour_palette_pgplot)
+    call giza_query_device('hardcopy', is_hardcopy)
+    if (trim(is_hardcopy) /= 'YES') then
+       call giza_draw_background()
+    endif
+ endif
 
 end function PGOPEN
 

--- a/src/giza-render.c
+++ b/src/giza-render.c
@@ -496,10 +496,9 @@ giza_render_gray_shade (int sizex, int sizey, const double* data, int i1,
                 int extend, int filter, const double *affine)
 {
   giza_save_colour_table();
-  if (fg >= bg)
-    giza_set_colour_table_gray ();
-  else
-    giza_set_colour_table_gray_inverted ();
+  giza_set_colour_table_gray ();
+  /* giza_render maps valMin (bg) to index 0 and valMax (fg) to index 99,
+   * so an inverted image (fg < bg) is handled without inverting the table */
   giza_render (sizex, sizey, data, i1, i2, j1, j2, bg, fg, extend, filter, affine);
   giza_restore_colour_table();
 }
@@ -517,10 +516,7 @@ giza_render_gray_shade_float (int sizex, int sizey, const float* data, int i1,
                 int extend, int filter, const float *affine)
 {
   giza_save_colour_table();
-  if (fg >= bg)
-    giza_set_colour_table_gray();
-  else
-    giza_set_colour_table_gray_inverted();
+  giza_set_colour_table_gray();
   giza_render_float (sizex, sizey, data, i1, i2, j1, j2, bg, fg, extend, filter, affine);
   giza_restore_colour_table();
 }

--- a/src/giza-render.c
+++ b/src/giza-render.c
@@ -460,6 +460,50 @@ giza_render_gray_float (int sizex, int sizey, const float* data, int i1,
 }
 
 /**
+ * Drawing: giza_render_gray_shade
+ *
+ * Synopsis: Greyscale image with explicit foreground and background data levels.
+ *           BG maps to the dark end of the ramp, FG to the light end.
+ *           When FG < BG the grey ramp is reversed automatically.
+ *
+ * See Also: giza_render_gray, giza_render_gray_shade_float
+ */
+void
+giza_render_gray_shade (int sizex, int sizey, const double* data, int i1,
+                int i2, int j1, int j2, double fg, double bg,
+                int extend, int filter, const double *affine)
+{
+  giza_save_colour_table();
+  if (fg >= bg)
+    giza_set_colour_table_gray ();
+  else
+    giza_set_colour_table_gray_inverted ();
+  giza_render (sizex, sizey, data, i1, i2, j1, j2, bg, fg, extend, filter, affine);
+  giza_restore_colour_table();
+}
+
+/**
+ * Drawing: giza_render_gray_shade_float
+ *
+ * Synopsis: Same as giza_render_gray_shade but with float data
+ *
+ * See Also: giza_render_gray_shade
+ */
+void
+giza_render_gray_shade_float (int sizex, int sizey, const float* data, int i1,
+                int i2, int j1, int j2, float fg, float bg,
+                int extend, int filter, const float *affine)
+{
+  giza_save_colour_table();
+  if (fg >= bg)
+    giza_set_colour_table_gray();
+  else
+    giza_set_colour_table_gray_inverted();
+  giza_render_float (sizex, sizey, data, i1, i2, j1, j2, bg, fg, extend, filter, affine);
+  giza_restore_colour_table();
+}
+
+/**
  * Sets the rgb for a given pixel, given position in the colour table.
  *
  * Input:

--- a/src/giza-render.c
+++ b/src/giza-render.c
@@ -32,6 +32,26 @@
 #include <math.h>
 
 /**
+ * Restrict drawing to the current world-coordinate window (PGPLOT window
+ * clipping). Viewport clipping alone does not crop cairo image paints correctly.
+ */
+static void
+_giza_clip_to_window (void)
+{
+  int clip;
+
+  giza_get_clipping (&clip);
+  if (!clip)
+    return;
+
+  cairo_rectangle (Dev[id].context,
+                   Dev[id].Win.xmin, Dev[id].Win.ymin,
+                   Dev[id].Win.xmax - Dev[id].Win.xmin,
+                   Dev[id].Win.ymax - Dev[id].Win.ymin);
+  cairo_clip (Dev[id].context);
+}
+
+/**
  * Drawing: giza_render
  *
  * Synopsis: Renders data to the device.
@@ -152,6 +172,7 @@ _giza_render (int sizex, int sizey, const double* data, int i1, int i2,
   _giza_set_trans (GIZA_TRANS_WORLD);
 
   cairo_save (Dev[id].context);
+  _giza_clip_to_window ();
 
   cairo_matrix_init (&mat, affine[0], affine[1], affine[2], affine[3],
                    affine[4], affine[5]);
@@ -339,6 +360,7 @@ _giza_render_float (int sizex, int sizey, const float* data, int i1,
   _giza_set_trans (GIZA_TRANS_WORLD);
 
   cairo_save (Dev[id].context);
+  _giza_clip_to_window ();
 
   cairo_matrix_init (&mat, (double) affine[0], (double) affine[1],
                    (double) affine[2], (double) affine[3],

--- a/src/giza.h
+++ b/src/giza.h
@@ -129,7 +129,6 @@ int giza_set_colour_table (const double *controlPoints, const double *red, const
 int giza_set_colour_table_float (const float *controlPoints, const float *red,
 				 const float *green, const float *blue, int n, float contrast, float brightness);
 int giza_set_colour_table_gray (void);
-int giza_set_colour_table_gray_inverted (void);
 void giza_save_colour_table (void);
 void giza_restore_colour_table (void);
 void giza_rgb_from_table (double pos, double *red, double *green,

--- a/src/giza.h
+++ b/src/giza.h
@@ -129,6 +129,7 @@ int giza_set_colour_table (const double *controlPoints, const double *red, const
 int giza_set_colour_table_float (const float *controlPoints, const float *red,
 				 const float *green, const float *blue, int n, float contrast, float brightness);
 int giza_set_colour_table_gray (void);
+int giza_set_colour_table_gray_inverted (void);
 void giza_save_colour_table (void);
 void giza_restore_colour_table (void);
 void giza_rgb_from_table (double pos, double *red, double *green,
@@ -343,6 +344,12 @@ void giza_render_gray (int sizex, int sizey, const double* data, int i1,
 void giza_render_gray_float (int sizex, int sizey, const float* data,
 			int i1, int i2, int j1, int j2, float valMin,
 			float valMax, int extend, int filter, const float *affine);
+void giza_render_gray_shade (int sizex, int sizey, const double* data, int i1,
+		  int i2, int j1, int j2, double fg, double bg, int extend,
+		  int filter, const double *affine);
+void giza_render_gray_shade_float (int sizex, int sizey, const float* data,
+			int i1, int i2, int j1, int j2, float fg, float bg,
+			int extend, int filter, const float *affine);
 void giza_draw_pixels (int sizex, int sizey, const int* idata, int i1, int i2,
 	    int j1, int j2, double xmin, double xmax, double ymin, double ymax, int extend, int filter);
 void giza_draw_pixels_float (int sizex, int sizey, const int* idata, int i1, int i2,

--- a/test/C/Makefile.am
+++ b/test/C/Makefile.am
@@ -12,7 +12,7 @@ LDADD += ../../src/libgiza-osxcocoa-main.la
 endif
 
 # Tests that run non-interactively (file-based devices only)
-auto_ctests = test-format-number test-pdf test-png test-svg test-unicode test-cairo-device \
+auto_ctests = test-format-number test-giza-round test-pdf test-png test-svg test-unicode test-cairo-device \
 	test-cpgpnts test-cpgconb test-cpgconf test-cpgconl test-cpgconx test-cpghi2d test-cpgscrl test-pggray
 
 # Tests that need an X display (use /xw or "?" which defaults to /xw)

--- a/test/C/Makefile.am
+++ b/test/C/Makefile.am
@@ -13,7 +13,7 @@ endif
 
 # Tests that run non-interactively (file-based devices only)
 auto_ctests = test-format-number test-pdf test-png test-svg test-unicode test-cairo-device \
-	test-cpgpnts test-cpgconb test-cpgconf test-cpgconl test-cpgconx test-cpghi2d test-cpgscrl
+	test-cpgpnts test-cpgconb test-cpgconf test-cpgconl test-cpgconx test-cpghi2d test-cpgscrl test-pggray
 
 # Tests that need an X display (use /xw or "?" which defaults to /xw)
 interactive_ctests = test-arrow test-box test-cairo-xw test-change-page \
@@ -35,6 +35,7 @@ test_cpgconl_LDADD = $(CPGPLOT_LDADD)
 test_cpgconx_LDADD = $(CPGPLOT_LDADD)
 test_cpghi2d_LDADD = $(CPGPLOT_LDADD)
 test_cpgscrl_LDADD = $(CPGPLOT_LDADD)
+test_pggray_LDADD = $(CPGPLOT_LDADD)
 
 test_cairo_xw_LDADD = $(LDADD) $(CAIRO_LIBS) $(X11_LIBS)
 test_cairo_device_LDADD = $(LDADD) $(CAIRO_LIBS)

--- a/test/C/Makefile.in
+++ b/test/C/Makefile.in
@@ -110,7 +110,8 @@ am__EXEEXT_1 = test-format-number$(EXEEXT) test-pdf$(EXEEXT) \
 	test-cairo-device$(EXEEXT) test-cpgpnts$(EXEEXT) \
 	test-cpgconb$(EXEEXT) test-cpgconf$(EXEEXT) \
 	test-cpgconl$(EXEEXT) test-cpgconx$(EXEEXT) \
-	test-cpghi2d$(EXEEXT) test-cpgscrl$(EXEEXT)
+	test-cpghi2d$(EXEEXT) test-cpgscrl$(EXEEXT) \
+	test-pggray$(EXEEXT)
 am__EXEEXT_2 = test-arrow$(EXEEXT) test-box$(EXEEXT) \
 	test-cairo-xw$(EXEEXT) test-change-page$(EXEEXT) \
 	test-circle$(EXEEXT) test-colour-index$(EXEEXT) \
@@ -218,6 +219,9 @@ test_pdf_SOURCES = test-pdf.c
 test_pdf_OBJECTS = test-pdf.$(OBJEXT)
 test_pdf_LDADD = $(LDADD)
 test_pdf_DEPENDENCIES = ../../src/libgiza.la $(am__append_1)
+test_pggray_SOURCES = test-pggray.c
+test_pggray_OBJECTS = test-pggray.$(OBJEXT)
+test_pggray_DEPENDENCIES = $(CPGPLOT_LDADD)
 test_png_SOURCES = test-png.c
 test_png_OBJECTS = test-png.$(OBJEXT)
 test_png_LDADD = $(LDADD)
@@ -287,11 +291,12 @@ am__depfiles_remade = ./$(DEPDIR)/test-XOpenDisplay.Po \
 	./$(DEPDIR)/test-format-number.Po ./$(DEPDIR)/test-giza-xw.Po \
 	./$(DEPDIR)/test-line-cap.Po ./$(DEPDIR)/test-line-style.Po \
 	./$(DEPDIR)/test-openclose.Po ./$(DEPDIR)/test-pdf.Po \
-	./$(DEPDIR)/test-png.Po ./$(DEPDIR)/test-points.Po \
-	./$(DEPDIR)/test-qtext.Po ./$(DEPDIR)/test-rectangle.Po \
-	./$(DEPDIR)/test-render.Po ./$(DEPDIR)/test-set-line-width.Po \
-	./$(DEPDIR)/test-svg.Po ./$(DEPDIR)/test-unicode.Po \
-	./$(DEPDIR)/test-vector.Po ./$(DEPDIR)/test-window.Po
+	./$(DEPDIR)/test-pggray.Po ./$(DEPDIR)/test-png.Po \
+	./$(DEPDIR)/test-points.Po ./$(DEPDIR)/test-qtext.Po \
+	./$(DEPDIR)/test-rectangle.Po ./$(DEPDIR)/test-render.Po \
+	./$(DEPDIR)/test-set-line-width.Po ./$(DEPDIR)/test-svg.Po \
+	./$(DEPDIR)/test-unicode.Po ./$(DEPDIR)/test-vector.Po \
+	./$(DEPDIR)/test-window.Po
 am__mv = mv -f
 COMPILE = $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) \
 	$(CPPFLAGS) $(AM_CFLAGS) $(CFLAGS)
@@ -318,8 +323,8 @@ SOURCES = test-XOpenDisplay.c test-arrow.c test-band.c test-box.c \
 	test-cpghi2d.c test-cpgpnts.c test-cpgscrl.c \
 	test-environment.c test-error-bars.c test-format-number.c \
 	test-giza-xw.c test-line-cap.c test-line-style.c \
-	test-openclose.c test-pdf.c test-png.c test-points.c \
-	test-qtext.c test-rectangle.c test-render.c \
+	test-openclose.c test-pdf.c test-pggray.c test-png.c \
+	test-points.c test-qtext.c test-rectangle.c test-render.c \
 	test-set-line-width.c test-svg.c test-unicode.c test-vector.c \
 	test-window.c
 DIST_SOURCES = test-XOpenDisplay.c test-arrow.c test-band.c test-box.c \
@@ -329,8 +334,8 @@ DIST_SOURCES = test-XOpenDisplay.c test-arrow.c test-band.c test-box.c \
 	test-cpghi2d.c test-cpgpnts.c test-cpgscrl.c \
 	test-environment.c test-error-bars.c test-format-number.c \
 	test-giza-xw.c test-line-cap.c test-line-style.c \
-	test-openclose.c test-pdf.c test-png.c test-points.c \
-	test-qtext.c test-rectangle.c test-render.c \
+	test-openclose.c test-pdf.c test-pggray.c test-png.c \
+	test-points.c test-qtext.c test-rectangle.c test-render.c \
 	test-set-line-width.c test-svg.c test-unicode.c test-vector.c \
 	test-window.c
 am__can_run_installinfo = \
@@ -724,7 +729,7 @@ CLEANFILES = *.png *.pdf *.svg
 
 # Tests that run non-interactively (file-based devices only)
 auto_ctests = test-format-number test-pdf test-png test-svg test-unicode test-cairo-device \
-	test-cpgpnts test-cpgconb test-cpgconf test-cpgconl test-cpgconx test-cpghi2d test-cpgscrl
+	test-cpgpnts test-cpgconb test-cpgconf test-cpgconl test-cpgconx test-cpghi2d test-cpgscrl test-pggray
 
 
 # Tests that need an X display (use /xw or "?" which defaults to /xw)
@@ -744,6 +749,7 @@ test_cpgconl_LDADD = $(CPGPLOT_LDADD)
 test_cpgconx_LDADD = $(CPGPLOT_LDADD)
 test_cpghi2d_LDADD = $(CPGPLOT_LDADD)
 test_cpgscrl_LDADD = $(CPGPLOT_LDADD)
+test_pggray_LDADD = $(CPGPLOT_LDADD)
 test_cairo_xw_LDADD = $(LDADD) $(CAIRO_LIBS) $(X11_LIBS)
 test_cairo_device_LDADD = $(LDADD) $(CAIRO_LIBS)
 test_XOpenDisplay_LDADD = $(LDADD) $(X11_LIBS)
@@ -885,6 +891,10 @@ test-pdf$(EXEEXT): $(test_pdf_OBJECTS) $(test_pdf_DEPENDENCIES) $(EXTRA_test_pdf
 	@rm -f test-pdf$(EXEEXT)
 	$(AM_V_CCLD)$(LINK) $(test_pdf_OBJECTS) $(test_pdf_LDADD) $(LIBS)
 
+test-pggray$(EXEEXT): $(test_pggray_OBJECTS) $(test_pggray_DEPENDENCIES) $(EXTRA_test_pggray_DEPENDENCIES) 
+	@rm -f test-pggray$(EXEEXT)
+	$(AM_V_CCLD)$(LINK) $(test_pggray_OBJECTS) $(test_pggray_LDADD) $(LIBS)
+
 test-png$(EXEEXT): $(test_png_OBJECTS) $(test_png_DEPENDENCIES) $(EXTRA_test_png_DEPENDENCIES) 
 	@rm -f test-png$(EXEEXT)
 	$(AM_V_CCLD)$(LINK) $(test_png_OBJECTS) $(test_png_LDADD) $(LIBS)
@@ -956,6 +966,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/test-line-style.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/test-openclose.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/test-pdf.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/test-pggray.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/test-png.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/test-points.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/test-qtext.Po@am__quote@ # am--include-marker
@@ -1309,6 +1320,13 @@ test-cpgscrl.log: test-cpgscrl$(EXEEXT)
 	--log-file $$b.log --trs-file $$b.trs \
 	$(am__common_driver_flags) $(AM_LOG_DRIVER_FLAGS) $(LOG_DRIVER_FLAGS) -- $(LOG_COMPILE) \
 	"$$tst" $(AM_TESTS_FD_REDIRECT)
+test-pggray.log: test-pggray$(EXEEXT)
+	@p='test-pggray$(EXEEXT)'; \
+	b='test-pggray'; \
+	$(am__check_pre) $(LOG_DRIVER) --test-name "$$f" \
+	--log-file $$b.log --trs-file $$b.trs \
+	$(am__common_driver_flags) $(AM_LOG_DRIVER_FLAGS) $(LOG_DRIVER_FLAGS) -- $(LOG_COMPILE) \
+	"$$tst" $(AM_TESTS_FD_REDIRECT)
 .test.log:
 	@p='$<'; \
 	$(am__set_b); \
@@ -1428,6 +1446,7 @@ distclean: distclean-am
 	-rm -f ./$(DEPDIR)/test-line-style.Po
 	-rm -f ./$(DEPDIR)/test-openclose.Po
 	-rm -f ./$(DEPDIR)/test-pdf.Po
+	-rm -f ./$(DEPDIR)/test-pggray.Po
 	-rm -f ./$(DEPDIR)/test-png.Po
 	-rm -f ./$(DEPDIR)/test-points.Po
 	-rm -f ./$(DEPDIR)/test-qtext.Po
@@ -1508,6 +1527,7 @@ maintainer-clean: maintainer-clean-am
 	-rm -f ./$(DEPDIR)/test-line-style.Po
 	-rm -f ./$(DEPDIR)/test-openclose.Po
 	-rm -f ./$(DEPDIR)/test-pdf.Po
+	-rm -f ./$(DEPDIR)/test-pggray.Po
 	-rm -f ./$(DEPDIR)/test-png.Po
 	-rm -f ./$(DEPDIR)/test-points.Po
 	-rm -f ./$(DEPDIR)/test-qtext.Po

--- a/test/C/Makefile.in
+++ b/test/C/Makefile.in
@@ -105,13 +105,13 @@ mkinstalldirs = $(install_sh) -d
 CONFIG_HEADER = $(top_builddir)/config.h
 CONFIG_CLEAN_FILES =
 CONFIG_CLEAN_VPATH_FILES =
-am__EXEEXT_1 = test-format-number$(EXEEXT) test-pdf$(EXEEXT) \
-	test-png$(EXEEXT) test-svg$(EXEEXT) test-unicode$(EXEEXT) \
-	test-cairo-device$(EXEEXT) test-cpgpnts$(EXEEXT) \
-	test-cpgconb$(EXEEXT) test-cpgconf$(EXEEXT) \
-	test-cpgconl$(EXEEXT) test-cpgconx$(EXEEXT) \
-	test-cpghi2d$(EXEEXT) test-cpgscrl$(EXEEXT) \
-	test-pggray$(EXEEXT)
+am__EXEEXT_1 = test-format-number$(EXEEXT) test-giza-round$(EXEEXT) \
+	test-pdf$(EXEEXT) test-png$(EXEEXT) test-svg$(EXEEXT) \
+	test-unicode$(EXEEXT) test-cairo-device$(EXEEXT) \
+	test-cpgpnts$(EXEEXT) test-cpgconb$(EXEEXT) \
+	test-cpgconf$(EXEEXT) test-cpgconl$(EXEEXT) \
+	test-cpgconx$(EXEEXT) test-cpghi2d$(EXEEXT) \
+	test-cpgscrl$(EXEEXT) test-pggray$(EXEEXT)
 am__EXEEXT_2 = test-arrow$(EXEEXT) test-box$(EXEEXT) \
 	test-cairo-xw$(EXEEXT) test-change-page$(EXEEXT) \
 	test-circle$(EXEEXT) test-colour-index$(EXEEXT) \
@@ -199,6 +199,10 @@ test_format_number_SOURCES = test-format-number.c
 test_format_number_OBJECTS = test-format-number.$(OBJEXT)
 test_format_number_LDADD = $(LDADD)
 test_format_number_DEPENDENCIES = ../../src/libgiza.la $(am__append_1)
+test_giza_round_SOURCES = test-giza-round.c
+test_giza_round_OBJECTS = test-giza-round.$(OBJEXT)
+test_giza_round_LDADD = $(LDADD)
+test_giza_round_DEPENDENCIES = ../../src/libgiza.la $(am__append_1)
 test_giza_xw_SOURCES = test-giza-xw.c
 test_giza_xw_OBJECTS = test-giza-xw.$(OBJEXT)
 test_giza_xw_LDADD = $(LDADD)
@@ -288,7 +292,8 @@ am__depfiles_remade = ./$(DEPDIR)/test-XOpenDisplay.Po \
 	./$(DEPDIR)/test-cpgconx.Po ./$(DEPDIR)/test-cpghi2d.Po \
 	./$(DEPDIR)/test-cpgpnts.Po ./$(DEPDIR)/test-cpgscrl.Po \
 	./$(DEPDIR)/test-environment.Po ./$(DEPDIR)/test-error-bars.Po \
-	./$(DEPDIR)/test-format-number.Po ./$(DEPDIR)/test-giza-xw.Po \
+	./$(DEPDIR)/test-format-number.Po \
+	./$(DEPDIR)/test-giza-round.Po ./$(DEPDIR)/test-giza-xw.Po \
 	./$(DEPDIR)/test-line-cap.Po ./$(DEPDIR)/test-line-style.Po \
 	./$(DEPDIR)/test-openclose.Po ./$(DEPDIR)/test-pdf.Po \
 	./$(DEPDIR)/test-pggray.Po ./$(DEPDIR)/test-png.Po \
@@ -322,22 +327,22 @@ SOURCES = test-XOpenDisplay.c test-arrow.c test-band.c test-box.c \
 	test-cpgconb.c test-cpgconf.c test-cpgconl.c test-cpgconx.c \
 	test-cpghi2d.c test-cpgpnts.c test-cpgscrl.c \
 	test-environment.c test-error-bars.c test-format-number.c \
-	test-giza-xw.c test-line-cap.c test-line-style.c \
-	test-openclose.c test-pdf.c test-pggray.c test-png.c \
-	test-points.c test-qtext.c test-rectangle.c test-render.c \
-	test-set-line-width.c test-svg.c test-unicode.c test-vector.c \
-	test-window.c
+	test-giza-round.c test-giza-xw.c test-line-cap.c \
+	test-line-style.c test-openclose.c test-pdf.c test-pggray.c \
+	test-png.c test-points.c test-qtext.c test-rectangle.c \
+	test-render.c test-set-line-width.c test-svg.c test-unicode.c \
+	test-vector.c test-window.c
 DIST_SOURCES = test-XOpenDisplay.c test-arrow.c test-band.c test-box.c \
 	test-cairo-device.c test-cairo-xw.c test-change-page.c \
 	test-circle.c test-colour-index.c test-contour.c \
 	test-cpgconb.c test-cpgconf.c test-cpgconl.c test-cpgconx.c \
 	test-cpghi2d.c test-cpgpnts.c test-cpgscrl.c \
 	test-environment.c test-error-bars.c test-format-number.c \
-	test-giza-xw.c test-line-cap.c test-line-style.c \
-	test-openclose.c test-pdf.c test-pggray.c test-png.c \
-	test-points.c test-qtext.c test-rectangle.c test-render.c \
-	test-set-line-width.c test-svg.c test-unicode.c test-vector.c \
-	test-window.c
+	test-giza-round.c test-giza-xw.c test-line-cap.c \
+	test-line-style.c test-openclose.c test-pdf.c test-pggray.c \
+	test-png.c test-points.c test-qtext.c test-rectangle.c \
+	test-render.c test-set-line-width.c test-svg.c test-unicode.c \
+	test-vector.c test-window.c
 am__can_run_installinfo = \
   case $$AM_UPDATE_INFO_DIR in \
     n|no|NO) false;; \
@@ -728,7 +733,7 @@ CPGPLOT_LDADD = ../../src/libcpgplot.la ../../src/libgiza.la
 CLEANFILES = *.png *.pdf *.svg
 
 # Tests that run non-interactively (file-based devices only)
-auto_ctests = test-format-number test-pdf test-png test-svg test-unicode test-cairo-device \
+auto_ctests = test-format-number test-giza-round test-pdf test-png test-svg test-unicode test-cairo-device \
 	test-cpgpnts test-cpgconb test-cpgconf test-cpgconl test-cpgconx test-cpghi2d test-cpgscrl test-pggray
 
 
@@ -871,6 +876,10 @@ test-format-number$(EXEEXT): $(test_format_number_OBJECTS) $(test_format_number_
 	@rm -f test-format-number$(EXEEXT)
 	$(AM_V_CCLD)$(LINK) $(test_format_number_OBJECTS) $(test_format_number_LDADD) $(LIBS)
 
+test-giza-round$(EXEEXT): $(test_giza_round_OBJECTS) $(test_giza_round_DEPENDENCIES) $(EXTRA_test_giza_round_DEPENDENCIES) 
+	@rm -f test-giza-round$(EXEEXT)
+	$(AM_V_CCLD)$(LINK) $(test_giza_round_OBJECTS) $(test_giza_round_LDADD) $(LIBS)
+
 test-giza-xw$(EXEEXT): $(test_giza_xw_OBJECTS) $(test_giza_xw_DEPENDENCIES) $(EXTRA_test_giza_xw_DEPENDENCIES) 
 	@rm -f test-giza-xw$(EXEEXT)
 	$(AM_V_CCLD)$(LINK) $(test_giza_xw_OBJECTS) $(test_giza_xw_LDADD) $(LIBS)
@@ -961,6 +970,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/test-environment.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/test-error-bars.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/test-format-number.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/test-giza-round.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/test-giza-xw.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/test-line-cap.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/test-line-style.Po@am__quote@ # am--include-marker
@@ -1236,6 +1246,13 @@ test-format-number.log: test-format-number$(EXEEXT)
 	--log-file $$b.log --trs-file $$b.trs \
 	$(am__common_driver_flags) $(AM_LOG_DRIVER_FLAGS) $(LOG_DRIVER_FLAGS) -- $(LOG_COMPILE) \
 	"$$tst" $(AM_TESTS_FD_REDIRECT)
+test-giza-round.log: test-giza-round$(EXEEXT)
+	@p='test-giza-round$(EXEEXT)'; \
+	b='test-giza-round'; \
+	$(am__check_pre) $(LOG_DRIVER) --test-name "$$f" \
+	--log-file $$b.log --trs-file $$b.trs \
+	$(am__common_driver_flags) $(AM_LOG_DRIVER_FLAGS) $(LOG_DRIVER_FLAGS) -- $(LOG_COMPILE) \
+	"$$tst" $(AM_TESTS_FD_REDIRECT)
 test-pdf.log: test-pdf$(EXEEXT)
 	@p='test-pdf$(EXEEXT)'; \
 	b='test-pdf'; \
@@ -1441,6 +1458,7 @@ distclean: distclean-am
 	-rm -f ./$(DEPDIR)/test-environment.Po
 	-rm -f ./$(DEPDIR)/test-error-bars.Po
 	-rm -f ./$(DEPDIR)/test-format-number.Po
+	-rm -f ./$(DEPDIR)/test-giza-round.Po
 	-rm -f ./$(DEPDIR)/test-giza-xw.Po
 	-rm -f ./$(DEPDIR)/test-line-cap.Po
 	-rm -f ./$(DEPDIR)/test-line-style.Po
@@ -1522,6 +1540,7 @@ maintainer-clean: maintainer-clean-am
 	-rm -f ./$(DEPDIR)/test-environment.Po
 	-rm -f ./$(DEPDIR)/test-error-bars.Po
 	-rm -f ./$(DEPDIR)/test-format-number.Po
+	-rm -f ./$(DEPDIR)/test-giza-round.Po
 	-rm -f ./$(DEPDIR)/test-giza-xw.Po
 	-rm -f ./$(DEPDIR)/test-line-cap.Po
 	-rm -f ./$(DEPDIR)/test-line-style.Po

--- a/test/C/test-giza-round.c
+++ b/test/C/test-giza-round.c
@@ -1,0 +1,69 @@
+/* giza test — giza_round tick-interval rounding */
+
+#include <giza.h>
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+typedef struct
+{
+  double input;
+  double expect;
+  int    expect_nsub;
+} round_case_t;
+
+static int
+almost_equal (double a, double b)
+{
+  double scale = fmax (fabs (a), fabs (b));
+  if (scale < 1.)
+    scale = 1.;
+  return fabs (a - b) < 1e-10 * scale;
+}
+
+int
+main (void)
+{
+  static round_case_t const cases[] = {
+    /* Representative inputs and expected outputs */
+    { 8.7,  10.,  5 },
+    { -0.4, -0.5, 5 },
+    /* Boundary and decade cases */
+    { 0.4,  0.5,  5 },
+    { 0.5,  0.5,  5 },
+    { 1.0,  2.0,  2 },
+    { 2.0,  2.0,  2 },
+    { 2.5,  5.0,  5 },
+    { 5.0,  5.0,  5 },
+    { 5.5,  10.,  5 },
+    { 9.5,  10.,  5 },
+    { 10.,  20.,  2 },
+    { 500., 500., 5 },
+    { 501., 1000., 5 },
+    { 950., 1000., 5 },
+    { 1000., 2000., 2 },
+    { 1001., 2000., 2 },
+    { 2000., 2000., 2 },
+    { 5000., 5000., 5 },
+    { 0., 0., 2 },
+  };
+  size_t i;
+  int failed = 0;
+
+  for (i = 0; i < sizeof (cases) / sizeof (cases[0]); i++)
+    {
+      int nsub;
+      double got = giza_round (cases[i].input, &nsub);
+
+      if (!almost_equal (got, cases[i].expect) || nsub != cases[i].expect_nsub)
+        {
+          fprintf (stderr,
+                   "giza_round(%g): got %g (nsub=%d), expected %g (nsub=%d)\n",
+                   cases[i].input, got, nsub, cases[i].expect,
+                   cases[i].expect_nsub);
+          failed++;
+        }
+    }
+
+  return failed ? EXIT_FAILURE : EXIT_SUCCESS;
+}

--- a/test/C/test-pggray.c
+++ b/test/C/test-pggray.c
@@ -1,0 +1,52 @@
+/* giza test — PGPLOT PGGRAY foreground/background colour semantics */
+
+#include <cpgplot.h>
+#include <stdio.h>
+
+#define NX 8
+#define NY 8
+
+int main(void)
+{
+  float data[NX * NY];
+  float tr[6];
+  float cr, cg, cb;
+  int i, j;
+
+  if (cpgopen("/null") <= 0)
+    return 1;
+
+  /* Classic PGPLOT: background black (CI 0), foreground white (CI 1) */
+  cpgqcr(0, &cr, &cg, &cb);
+  if (cr > 0.1f || cg > 0.1f || cb > 0.1f)
+    return 2;
+
+  cpgqcr(1, &cr, &cg, &cb);
+  if (cr < 0.9f || cg < 0.9f || cb < 0.9f)
+    return 3;
+
+  for (j = 0; j < NY; j++)
+    for (i = 0; i < NX; i++)
+      data[j * NX + i] = (float) (i + j);
+
+  tr[0] = 0.0f;
+  tr[1] = 1.0f;
+  tr[2] = 0.0f;
+  tr[3] = 0.0f;
+  tr[4] = 0.0f;
+  tr[5] = 1.0f;
+
+  cpgenv(0.0f, (float) NX, 0.0f, (float) NY, 1, 0);
+
+  /* Positive image: FG > BG */
+  cpggray(data, NX, NY, 1, NX, 1, NY, 14.0f, 0.0f, tr);
+
+  cpgpage();
+  cpgenv(0.0f, (float) NX, 0.0f, (float) NY, 1, 0);
+
+  /* Inverted image: FG < BG (issue #7) */
+  cpggray(data, NX, NY, 1, NX, 1, NY, 0.0f, 14.0f, tr);
+
+  cpgend();
+  return 0;
+}


### PR DESCRIPTION
fixes #7 and #4

- fixes issue with tick directions when axes are inverted
- fixes a clipping issue found in pggray rendering
- applies default PGPLOT colour palette when called through the PGPLOT API (do we *really* want this?)
- numerous fixes to giza-colour-bar.c, a routine that is not used in splash and needed some work to bring it into alignment with PGWEDG behaviour

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added new grayscale “shade” rendering APIs with configurable foreground/background mapping.

* **Bug Fixes**
  * Fixed y-axis time-label formatting modifiers being applied incorrectly.
  * Improved tick “nice number” rounding at exact boundary values.
  * Enhanced colour bar rendering/layout, including more consistent label behavior (e.g., skipping blank labels).

* **Documentation**
  * Updated API docs for the new grayscale shade functions and clarified colour bar `width`.

* **Tests**
  * Added/expanded automated tests for tick rounding and PGPLOT grayscale color semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->