### PR TITLE
fix: set clipping before device_open

### DIFF
--- a/src/giza-drivers.c
+++ b/src/giza-drivers.c
@@ -357,9 +357,6 @@ _giza_complete_device_open (int draw_background)
   _giza_init_window ();
 
   if (!defer_cairo)
-    giza_set_viewport_default ();
-
-  if (!defer_cairo)
     {
       giza_set_line_width (1);
       _giza_init_fill ();
@@ -367,6 +364,9 @@ _giza_complete_device_open (int draw_background)
       _giza_init_save ();
       giza_set_clipping (1);
     }
+
+  if (!defer_cairo)
+    giza_set_viewport_default ();
 
   return id + 1;
 }


### PR DESCRIPTION
- fixes #103

<img width="800" height="600" alt="clipD" src="https://github.com/user-attachments/assets/a76c2402-9551-4606-825a-45a41693cfd9" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved device initialization and viewport setup sequencing.
  * Ensured the default viewport is applied after initial drawing state and clipping are configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->