### PR TITLE
Fix filled histogram style (pghist pgflag=2): missing case + antialiasing seams

### DIFF
--- a/src/giza-histogram.c
+++ b/src/giza-histogram.c
@@ -92,6 +92,7 @@ giza_histogram (int n, const double *dat, double min, double max, int nbin, int 
     default:
       giza_set_fill(GIZA_FILL_HOLLOW);
       break;
+    case 2:
     case 3:
       giza_set_fill(GIZA_FILL_SOLID);
       break;
@@ -101,20 +102,42 @@ giza_histogram (int n, const double *dat, double min, double max, int nbin, int 
   _giza_set_trans (GIZA_TRANS_WORLD);
 
   /* plot the bars of the histogram */
-  for (ibin=0;ibin<nbin;ibin++)
+  if (flag == 2 || flag == 3)
     {
-       xmin = min + ibin*bin_width;
-       xmax = xmin + bin_width;
-       ymin = 0.;
-       ymax = (double) ninbin[ibin];
+      /* filled style: draw the whole histogram as a single closed
+       * staircase polygon and fill it once. Filling each bar as a
+       * separate polygon leaves antialiased seams between adjacent
+       * bars (two half-covered edges do not sum to full coverage) */
+      cairo_move_to (Dev[id].context, min, 0.);
+      for (ibin=0;ibin<nbin;ibin++)
+        {
+           xmin = min + ibin*bin_width;
+           xmax = xmin + bin_width;
+           ymax = (double) ninbin[ibin];
+           cairo_line_to (Dev[id].context, xmin, ymax);
+           cairo_line_to (Dev[id].context, xmax, ymax);
+        }
+      cairo_line_to (Dev[id].context, max, 0.);
+      cairo_close_path (Dev[id].context);
+      _giza_fill ();
+    }
+  else
+    {
+      for (ibin=0;ibin<nbin;ibin++)
+        {
+           xmin = min + ibin*bin_width;
+           xmax = xmin + bin_width;
+           ymin = 0.;
+           ymax = (double) ninbin[ibin];
 
-       /* plot only 3 sides of the rectangle for all except the last */
-       cairo_move_to (Dev[id].context, xmin, ymin);
-       cairo_line_to (Dev[id].context, xmin, ymax);
-       cairo_line_to (Dev[id].context, xmax, ymax);
-       cairo_line_to (Dev[id].context, xmax, ymin);
-       cairo_line_to (Dev[id].context, xmin, ymin);
-       _giza_fill ();
+           /* plot only 3 sides of the rectangle for all except the last */
+           cairo_move_to (Dev[id].context, xmin, ymin);
+           cairo_line_to (Dev[id].context, xmin, ymax);
+           cairo_line_to (Dev[id].context, xmax, ymax);
+           cairo_line_to (Dev[id].context, xmax, ymin);
+           cairo_line_to (Dev[id].context, xmin, ymin);
+           _giza_fill ();
+        }
     }
 
   /* restore previous fill style */


### PR DESCRIPTION
Fixes #6 (filled histogram, open since 2018 🙂). Two related fixes in `giza_histogram`:

**1. `flag=2` never selected the solid fill style.**
The style switch only listed `case 3:`, so `flag=2` (filled, with automatic `giza_set_environment`) fell through to `default:` → hollow. This is exactly the path `pghist(..., pgflag=2)` takes through the PGPLOT interface, which was the original report (perl-PGPLOT `test3.p` / `t/t3.t`). Now `case 2:` and `case 3:` both select `GIZA_FILL_SOLID`, matching the documented flag meanings in the function's own header comment.

**2. Filled bars showed dark seams between adjacent bins.**
Each bar was filled as a separate polygon. Where two bars abut, cairo antialiasing gives each edge roughly half pixel coverage, and two half-covered edges of the same colour composite to less than full coverage — a visible dark seam line between every pair of bars. The filled style now draws the entire histogram as a single closed staircase polygon and fills it once, so there are no interior edges to antialias. Hollow and outline styles (flags 0/1/4/5) keep the existing per-bar drawing and are unchanged.

**Testing:** verified via the perl-PGPLOT test suite (`t/t3.t`, the test behind #6) on `/xw`, `/osx` and `/png`, and compared side-by-side against original PGPLOT 5.3.1 output — bar shapes and fill now match. Screenshots in the comment below: giza before the seam fix vs original PGPLOT, and giza after both fixes.

Note in passing: `giza_histogram_binned` still fills per-rectangle and would show the same seams if used with a solid fill style; left unchanged here since `PGBIN` semantics are an outline staircase. Happy to extend the same treatment if wanted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved filled histogram rendering for styles 2 and 3.
  * Removed visible antialiased seams between adjacent histogram bars.
  * Preserved existing rendering behavior for other histogram styles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->