### PR TITLE
Band graphics in current colour index + live crosshair cursor on /xw (revisits #22)

### DIFF
--- a/src/giza-band.c
+++ b/src/giza-band.c
@@ -112,6 +112,13 @@ _giza_refresh_band (int mode, int nanc, const int *xanc, const int *yanc, int x2
   if (mode <= 0 || mode > GIZA_MAX_BAND_MODES) return;
   if (nanc <= 0) return;
 
+  /* draw the band in the current foreground colour, as PGPLOT does */
+  int bandci;
+  double bandr, bandg, bandb;
+  giza_get_colour_index (&bandci);
+  giza_get_colour_representation (bandci, &bandr, &bandg, &bandb);
+  cairo_set_source_rgba (Band.box, bandr, bandg, bandb, 1.);
+
   /* Draw over the old band */
   cairo_paint (Band.restore);
   giza_flush_device();
@@ -148,9 +155,9 @@ _giza_refresh_band (int mode, int nanc, const int *xanc, const int *yanc, int x2
        /* Draw the band */
         for (j=0;j<=1;j++) {
            if (j==0) {
-              cairo_set_source_rgba (Band.box,1.,1.,1.,0.2);
+              cairo_set_source_rgba (Band.box, bandr, bandg, bandb, 0.2);
            } else {
-              cairo_set_source_rgba (Band.box, 0.6, 0.6, 0.6, 1.0);
+              cairo_set_source_rgba (Band.box, bandr, bandg, bandb, 1.0);
            }
           cairo_move_to (Band.box, xanc[0], yanc[0]);
            for (i=1;i<=nanc-1;i++) {
@@ -171,7 +178,7 @@ _giza_refresh_band (int mode, int nanc, const int *xanc, const int *yanc, int x2
         cairo_set_source_rgba(Band.box,1.,1.,1.,0.2);
         cairo_rectangle (Band.box, x1, y1, x2 - x1, y2 - y1);
         cairo_fill(Band.box);
-        cairo_set_source_rgba (Band.box, 0.6, 0.6, 0.6, 1.0);
+        cairo_set_source_rgba (Band.box, bandr, bandg, bandb, 1.0);
         cairo_rectangle (Band.box, x1, y1, x2 - x1, y2 - y1);
         cairo_stroke(Band.box);
        break;
@@ -210,7 +217,7 @@ _giza_refresh_band (int mode, int nanc, const int *xanc, const int *yanc, int x2
         cairo_set_source_rgba(Band.box,1.,1.,1.,0.2);
         cairo_arc (Band.box, x1, y1, sqrt((x2-x1)*(x2-x1) + (y2-y1)*(y2-y1)), 0., 2 * M_PI);
         cairo_fill(Band.box);
-        cairo_set_source_rgba (Band.box, 0.6, 0.6, 0.6, 1.0);
+        cairo_set_source_rgba (Band.box, bandr, bandg, bandb, 1.0);
         cairo_arc (Band.box, x1, y1, sqrt((x2-x1)*(x2-x1) + (y2-y1)*(y2-y1)), 0., 2 * M_PI);
         cairo_stroke (Band.box);
        break;

--- a/src/giza-driver-xw.c
+++ b/src/giza-driver-xw.c
@@ -30,6 +30,7 @@
 #include "giza-transforms-private.h"
 #include "giza-character-size-private.h"
 #include "giza-band-private.h"
+#include <X11/cursorfont.h>
 
 #ifdef _GIZA_HAS_XW
 
@@ -458,6 +459,10 @@ _giza_xevent_loop (int mode, int moveCurs, int nanc, const int *anchorx, const i
   _giza_init_band (mode);
   _giza_expand_clipping_xw();
 
+  /* show a live crosshair cursor while waiting for input, as PGPLOT does */
+  Cursor livecursor = XCreateFontCursor (XW[id].display, XC_crosshair);
+  XDefineCursor (XW[id].display, XW[id].window, livecursor);
+
  while(1) {
 
     /* wait for key press/expose (avoid using XNextEvent as breaks older systems) */
@@ -472,11 +477,14 @@ _giza_xevent_loop (int mode, int moveCurs, int nanc, const int *anchorx, const i
     case ClientMessage: /* catch close window event */
       *ch = 'q';
        if ((Atom)event.xclient.data.l[0] == wmDeleteMessage) {
+          XUndefineCursor (XW[id].display, XW[id].window);
+          XFreeCursor (XW[id].display, livecursor);
           return;
        }
        break;
     case DestroyNotify:
       *ch = 'q';
+      XFreeCursor (XW[id].display, livecursor);
       return;
     case Expose: /* redraw */
       _giza_expose_xw (&event);
@@ -502,6 +510,8 @@ _giza_xevent_loop (int mode, int moveCurs, int nanc, const int *anchorx, const i
           _giza_destroy_band (mode);
           _giza_flush_xw_event_queue(&event);
           _giza_reset_clipping_xw();
+          XUndefineCursor (XW[id].display, XW[id].window);
+          XFreeCursor (XW[id].display, livecursor);
          return;
        };
 
@@ -544,6 +554,8 @@ _giza_xevent_loop (int mode, int moveCurs, int nanc, const int *anchorx, const i
         _giza_destroy_band (mode);
         _giza_flush_xw_event_queue(&event);
         _giza_reset_clipping_xw();
+        XUndefineCursor (XW[id].display, XW[id].window);
+        XFreeCursor (XW[id].display, livecursor);
         return;
       }
     case MotionNotify:


### PR DESCRIPTION
Revisits #22 (closed wontfix in 2022) — given the recent PGPLOT-compatibility work (perl-PGPLOT tests in CI, #99/#105), I hope these two small interactivity fixes are now welcome.

**1. Band graphics follow the current colour index.**
`_giza_refresh_band` drew the rubber-band graphics in hardcoded grey `(0.6, 0.6, 0.6)`; PGPLOT uses the current pen colour (that was the original report in #22). The band now fetches the current colour via `giza_get_colour_index`/`giza_get_colour_representation` and uses it for the strokes, and at 20% alpha for the translucent rectangle/circle fills (previously white). This is in shared code, so it applies to `/xw` and `/osx` alike.

**2. Live crosshair cursor during cursor input (`/xw`).**
The X driver never changed the pointer shape, so interactive cursor input showed the standard arrow. PGPLOT's X driver switches between a `norm_cursor` and a `live_cursor`; `_giza_xevent_loop` now displays an `XC_crosshair` for the duration of the interactive loop and restores the normal pointer on all exit paths. (The `/osx` driver would want the `NSCursor.crosshairCursor` equivalent — not attempted here.)

**Testing:** perl-PGPLOT test suite `t/t9.t` on `/xw` on macOS — PGBAND modes 0–7 each preceded by a different `pgsci`, all now draw in their colour with the crosshair pointer active, reverting on keypress. Full suite still passes on `/NULL` and `/png`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Band overlays now use the current foreground color, improving visual consistency across line, rectangle, and circle displays.
  * Added a live crosshair cursor during interactive input to make pointer positioning clearer.
  * The crosshair is properly removed after input is completed or the window closes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->