### PR TITLE
/osx driver: fix white-out, band colour, and elastic anchor during cursor input; restore PGLCUR committed segments

### DIFF
--- a/src/giza-cursor-routines.c
+++ b/src/giza-cursor-routines.c
@@ -126,9 +126,10 @@ _giza_mark_with_cursor (int maxpts, int *npts, double* xpts, double* ypts,
              }
              if (mode == GIZA_BAND_LINE && *npts > 1)
                {
-                 /*giza_move(xpts[*npts-2],ypts[*npts-2]);
+                 /* draw the committed segment, as PGPLOT PGLCUR does
+                  * ("a line is drawn joining each point to the previous") */
+                 giza_move(xpts[*npts-2],ypts[*npts-2]);
                  giza_draw(xpts[*npts-1],ypts[*npts-1]);
-                */
                } else {
                  giza_single_point(x,y,symbol);
                }

--- a/src/giza-driver-osxcocoa-bridge.c
+++ b/src/giza-driver-osxcocoa-bridge.c
@@ -319,7 +319,6 @@ _giza_get_key_press_osxcocoa (int mode, int moveCurs,
                           double *x, double *y, char *ch)
 {
     (void) moveCurs;
-    (void) nanc;
 
     int oldTrans = _giza_get_trans();
     _giza_set_trans(GIZA_TRANS_WORLD);
@@ -327,10 +326,19 @@ _giza_get_key_press_osxcocoa (int mode, int moveCurs,
     float fx, fy;
     /* attach + wait + detach on main thread to avoid deadlock */
     if (mode > 0) {
-        /* Convert anchor world coords to device (surface) coords for band overlay */
-        double axd = xanc[0], ayd = yanc[0];
+        /* Convert anchor world coords to device (surface) coords for band
+         * overlay. Use the LAST anchor: for polyline entry (pglcur) the
+         * anchors are all committed points and the elastic line must
+         * connect to the most recent one, as the xw driver does. */
+        double axd = xanc[nanc-1], ayd = yanc[nanc-1];
         cairo_user_to_device(Dev[id].context, &axd, &ayd);
-        _giza_osxcocoa_wait_for_event_band(id, mode, (float)axd, (float)ayd, &fx, &fy, ch);
+        /* band drawn in the current colour index, as PGPLOT does */
+        int bandci;
+        double bandr, bandg, bandb;
+        giza_get_colour_index (&bandci);
+        giza_get_colour_representation (bandci, &bandr, &bandg, &bandb);
+        _giza_osxcocoa_wait_for_event_band(id, mode, (float)axd, (float)ayd,
+                                           (float)bandr, (float)bandg, (float)bandb, &fx, &fy, ch);
     } else {
         _giza_osxcocoa_wait_for_event(id, &fx, &fy, ch);
     }

--- a/src/giza-driver-osxcocoa-private.h
+++ b/src/giza-driver-osxcocoa-private.h
@@ -62,6 +62,7 @@ void         _giza_osxcocoa_wait_for_event       (int devId,
                                              float *x, float *y, char *ch);
 void         _giza_osxcocoa_wait_for_event_band  (int devId, int mode,
                                              float xancSurface, float yancSurface,
+                                             float bandR, float bandG, float bandB,
                                              float *x, float *y, char *ch);
 
 #endif /* __APPLE__ */

--- a/src/giza-driver-osxcocoa.m
+++ b/src/giza-driver-osxcocoa.m
@@ -84,6 +84,7 @@
     int     _surfW;      /* source surface size (for full-width lines) */
     int     _surfH;
     CGRect  _displayRect;/* same letterbox rect as parent GizaView */
+    float   _bandR, _bandG, _bandB; /* band colour (current colour index) */
 }
 - (instancetype)initWithFrame:(NSRect)frame
                          mode:(int)mode
@@ -91,6 +92,7 @@
                       surfaceSize:(NSSize)ss
                       displayRect:(CGRect)dr;
 - (void)updateCursor:(NSPoint)surfPt displayRect:(CGRect)dr;
+- (void)setBandColorR:(float)r G:(float)g B:(float)b;
 @end
 
 @implementation GizaBandView
@@ -109,6 +111,7 @@
         _surfW  = (int)ss.width;
         _surfH  = (int)ss.height;
         _displayRect = dr;
+        _bandR = 0.9f; _bandG = 0.9f; _bandB = 0.9f;
     }
     return self;
 }
@@ -131,14 +134,16 @@
 - (void)drawRect:(NSRect)dirtyRect
 {
     CGContextRef ctx = [[NSGraphicsContext currentContext] CGContext];
-    CGContextClearRect(ctx, NSRectToCGRect(self.bounds));
-
+    /* NOTE: no CGContextClearRect here. On a non-layer-backed transparent
+     * view it punches through the composited backing store to the window
+     * background (white), blanking the whole plot during cursor input.
+     * AppKit has already composited the views beneath us. */
     if (_mode <= 0) return;
 
-    /* Style: white line with 40% opacity fill for area modes */
+    /* Style: current colour index, translucent fill for area modes */
     CGContextSetLineWidth(ctx, 1.5);
-    CGContextSetRGBStrokeColor(ctx, 0.9, 0.9, 0.9, 1.0);
-    CGContextSetRGBFillColor  (ctx, 1.0, 1.0, 1.0, 0.15);
+    CGContextSetRGBStrokeColor(ctx, _bandR, _bandG, _bandB, 1.0);
+    CGContextSetRGBFillColor  (ctx, _bandR, _bandG, _bandB, 0.15);
 
     CGPoint a = [self _viewPtFromSurface:_anchor];
     CGPoint c = [self _viewPtFromSurface:_cursor];
@@ -216,6 +221,11 @@
     [self setNeedsDisplay:YES];
 }
 
+- (void)setBandColorR:(float)r G:(float)g B:(float)b
+{
+    _bandR = r; _bandG = g; _bandB = b;
+}
+
 @end
 
 /* ======================================================================== */
@@ -253,7 +263,7 @@
 - (NSPoint)surfacePointFromViewPoint:(NSPoint)vp;
 - (NSPoint)currentMouseViewPoint;
 /* band control */
-- (void)attachBandViewMode:(int)mode anchorSurfacePt:(NSPoint)anc;
+- (void)attachBandViewMode:(int)mode anchorSurfacePt:(NSPoint)anc colorR:(float)r G:(float)g B:(float)b;
 - (void)detachBandView;
 @end
 
@@ -431,7 +441,7 @@
 }
 
 /* Attach a GizaBandView overlay */
-- (void)attachBandViewMode:(int)mode anchorSurfacePt:(NSPoint)anc
+- (void)attachBandViewMode:(int)mode anchorSurfacePt:(NSPoint)anc colorR:(float)r G:(float)g B:(float)b
 {
     [self detachBandView];
     NSSize ss = NSMakeSize(_pixelWidth > 0 ? _pixelWidth : (int)self.bounds.size.width,
@@ -442,6 +452,7 @@
                            anchor:anc
                       surfaceSize:ss
                       displayRect:_displayRect];
+    [_bandView setBandColorR:r G:g B:b];
     [self addSubview:_bandView];
     _bandActive = YES;
 }
@@ -713,6 +724,7 @@ _giza_osxcocoa_wait_for_event(int devId, float *x, float *y, char *ch)
 void
 _giza_osxcocoa_wait_for_event_band(int devId, int mode,
                                    float xancSurface, float yancSurface,
+                                   float bandR, float bandG, float bandB,
                                    float *x, float *y, char *ch)
 {
     if (!_osxcocoa_inuse[devId]) { *ch='q'; return; }
@@ -721,7 +733,7 @@ _giza_osxcocoa_wait_for_event_band(int devId, int mode,
     __block char c = ' ';
     _run_on_main(^{
         NSPoint anc = NSMakePoint(xancSurface, yancSurface);
-        [view attachBandViewMode:mode anchorSurfacePt:anc];
+        [view attachBandViewMode:mode anchorSurfacePt:anc colorR:bandR G:bandG B:bandB];
         [view waitForInputEventWithBand];
         pt = [view lastEventPoint];
         c  = [view lastEventChar];


### PR DESCRIPTION
Testing the new `/osx` Cocoa driver interactively with the perl-PGPLOT suite (`t/t2.t` polyline entry via PGLCUR, `t/t9.t` PGBAND modes 0–7) turned up four issues around cursor input, in two commits:

**1. The whole plot went white during cursor input.**
`GizaBandView`'s `drawRect` began with `CGContextClearRect` over its bounds. On a non-layer-backed transparent view that doesn't reveal the sibling view beneath — it punches through the composited window backing store to the `NSWindow` background, which is white by default. First mouse event → entire panel blanks; it only recomposites when the overlay detaches. AppKit composites everything beneath a transparent view *before* calling its `drawRect`, so the clear is unnecessary — removed.

**2. Band shapes ignored the colour index.**
Hardcoded light grey; now the current colour representation is passed through `attachBandViewMode` so bands follow `pgsci` — the Cocoa counterpart of the `/xw` fix in #107. (t9 sets a different colour per PGBAND mode, which makes a nice test.)

**3. The elastic band anchored at the wrong end of the polyline.**
The bridge used `xanc[0]` and ignored `nanc`. During PGLCUR entry the anchors are all committed points; the elastic must connect to the most recent one (`anchor[nanc-1]`, as the xw event loop does). Anchored at the first point, the band stretched from the wrong end of the chain.

**4. Committed polyline segments were never drawn (all interactive devices).**
PGPLOT's PGLCUR permanently draws a line joining each entered point to the previous one. giza had exactly this code in `_giza_mark_with_cursor` — commented out. On `/xw` the band polyline (drawn through all anchors) masked the absence; on `/osx`, whose native band takes a single anchor, the chain was missing entirely. Restored, so both drivers now match classic behaviour.

**Testing:** verified interactively on macOS 15 / Apple Silicon in the perl fallback mode (host `main()`, no `giza_main`): t2 polyline entry shows the committed chain plus an elastic band from the last point in the current colour, t9's PGBAND modes render each shape in its `pgsci` colour with the plot visible throughout. Full perl-PGPLOT suite passes on `/NULL` and `/png`.
