### PR TITLE
PGPLOT interface: black background on /png (as PGPLOT), paper-white with black ink on /ps,/pdf; document non-retroactive colour tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,18 @@ Features
 - Easily called from Fortran/C/C++ code
 - Originally written as a backend for SPLASH, in stable use now for more than 15 years
 
+Differences from PGPLOT
+-----------------------
+- Colour table changes are not retroactive. giza renders in immediate-mode
+  truecolour via cairo, so PGCTAB / giza_set_colour_table affects only
+  images drawn afterwards. Legacy code that calls PGCTAB *after* PGIMAG -
+  relying on the indexed-colour behaviour of 8-bit displays, where
+  rewriting the colormap retroactively recoloured whatever was already on
+  screen - must set the colour table first. Colormap-animation tricks are
+  likewise unsupported. (Modern PGPLOT has the same limitation on TrueColor
+  X visuals; the retroactive behaviour now survives only in PGPLOT's
+  indexed PNG files.)
+
 Status
 ------
 ![build](https://github.com/danieljprice/giza/workflows/build/badge.svg)

--- a/src/giza-cpgplot.c
+++ b/src/giza-cpgplot.c
@@ -31,6 +31,7 @@
 
 #include "giza.h"
 #include "giza-private.h"
+#include "giza-drivers-private.h"
 #include "giza-io-private.h" /* for _giza_error() */
 #include "giza-driver-xw-private.h"
 #include "giza-driver-eps-private.h"
@@ -725,8 +726,24 @@ int cpgopen(const char *device)
       int len = sizeof(is_hardcopy);
       giza_set_colour_palette(GIZA_COLOUR_PALETTE_PGPLOT);
       giza_query_device("hardcopy", is_hardcopy, &len);
-      if (strcmp(is_hardcopy, "YES") != 0)
-        giza_draw_background();
+      if (strcmp(is_hardcopy, "YES") != 0
+          || Dev[id].type == GIZA_DEVICE_PNG || Dev[id].type == GIZA_DEVICE_MP4)
+        {
+          /* interactive devices and raster files: PGPLOT screen convention
+           * (black background, white foreground - matching PGPLOT's PNG
+           * driver, which renders white-on-black like /xw) */
+          giza_draw_background();
+        }
+      else
+        {
+          /* vector hardcopy (ps/eps/pdf/svg): PGPLOT paper convention -
+           * white background with BLACK foreground, as the classic PS
+           * driver. Without this the PGPLOT palette leaves the foreground
+           * white on giza's white page: invisible ink */
+          giza_set_colour_representation(GIZA_BACKGROUND_COLOUR, 1., 1., 1.);
+          giza_set_colour_representation(GIZA_FOREGROUND_COLOUR, 0., 0., 0.);
+          giza_draw_background();
+        }
     }
   return pgopen;
 }


### PR DESCRIPTION
Through the PGPLOT interface, `/png` output had a white background with white foreground unless the program happened to call `PGENV`, and `/pdf`, `/ps` drew white-on-white — invisible ink. Found with perl-PGPLOT `t/t12.t` (which draws via `pgwnad`, no `PGENV`), compared against PGPLOT 5.3.1's PNG driver.

**Cause:** `cpgopen` applies the PGPLOT colour palette (black background, white foreground, from #100) but skips the `giza_draw_background` repaint for hardcopy devices — and giza classifies `/png` and `/pdf` as hardcopy. Those devices therefore keep the surface's native white background while the foreground remains PGPLOT-white. The inconsistency was masked whenever `PGENV` was called, because `PGPAGE` repaints the background unconditionally.

**Fix:** match PGPLOT's actual per-device conventions in `cpgopen`:

- raster files (`/png`, `/mp4`): screen convention — paint the black background, white foreground — as PGPLOT's PNG driver renders;
- vector hardcopy (`/ps`, `/eps`, `/pdf`, `/svg`): paper convention — white background with **black** foreground, as the classic PS driver. Without the foreground flip, PGPLOT-white ink is invisible on giza's white page.

Direct giza API users are unaffected; the change is confined to `cpgopen`.

**Also (second commit):** documents in the README that colour table changes are not retroactive under giza. perl-PGPLOT `t/t9.t` deliberately calls `PGCTAB` *after* `PGIMAG`, relying on 1990s indexed-colour devices recolouring the already-drawn image; cairo's immediate-mode truecolour rendering cannot honour that, and modern PGPLOT itself only retains the behaviour in its indexed PNG output (its `/xw` on TrueColor visuals shows greyscale too — verified side by side). Documented as a difference rather than surprising the next person porting legacy code.

**Testing:** `t/t12.t` on `/png` now renders with the same conventions as PGPLOT 5.3.1's PNG output (black background, all annotation visible); `/pdf` and `/ps` output measured white-page/black-ink; full perl-PGPLOT suite passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added documentation clarifying color-table behavior and limitations across rendered images and indexed PNG output.
  * Improved default background and foreground colors for vector output, using white backgrounds with black content.

* **Bug Fixes**
  * Preserved black-background behavior for interactive displays and PNG/MP4 outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->