### PR TITLE
pggray: make FG < BG produce a negative image (completes #7)

### DIFF
--- a/src/giza-render.c
+++ b/src/giza-render.c
@@ -496,10 +496,24 @@ giza_render_gray_shade (int sizex, int sizey, const double* data, int i1,
                 int extend, int filter, const double *affine)
 {
   giza_save_colour_table();
-  giza_set_colour_table_gray ();
-  /* giza_render maps valMin (bg) to index 0 and valMax (fg) to index 99,
-   * so an inverted image (fg < bg) is handled without inverting the table */
-  giza_render (sizex, sizey, data, i1, i2, j1, j2, bg, fg, extend, filter, affine);
+  if (fg >= bg)
+    {
+      giza_set_colour_table_gray ();
+      giza_render (sizex, sizey, data, i1, i2, j1, j2, bg, fg, extend, filter, affine);
+    }
+  else
+    {
+      /* fg < bg requests a negative image (PGGRAY interpolates the shade
+       * from bg to fg, so swapped levels invert). The value normalisation
+       * in giza-itf.c is symmetric under min/max exchange, so the
+       * inversion cannot come from swapping valMin/valMax - use a
+       * white->black ramp with the levels in ascending order instead */
+      double cp[2], ramp[2];
+      cp[0] = 0.; ramp[0] = 1.;
+      cp[1] = 1.; ramp[1] = 0.;
+      giza_set_colour_table (cp, ramp, ramp, ramp, 2, 1., 0.5);
+      giza_render (sizex, sizey, data, i1, i2, j1, j2, fg, bg, extend, filter, affine);
+    }
   giza_restore_colour_table();
 }
 
@@ -516,8 +530,20 @@ giza_render_gray_shade_float (int sizex, int sizey, const float* data, int i1,
                 int extend, int filter, const float *affine)
 {
   giza_save_colour_table();
-  giza_set_colour_table_gray();
-  giza_render_float (sizex, sizey, data, i1, i2, j1, j2, bg, fg, extend, filter, affine);
+  if (fg >= bg)
+    {
+      giza_set_colour_table_gray();
+      giza_render_float (sizex, sizey, data, i1, i2, j1, j2, bg, fg, extend, filter, affine);
+    }
+  else
+    {
+      /* negative image: see giza_render_gray_shade */
+      double cp[2], ramp[2];
+      cp[0] = 0.; ramp[0] = 1.;
+      cp[1] = 1.; ramp[1] = 0.;
+      giza_set_colour_table (cp, ramp, ramp, ramp, 2, 1., 0.5);
+      giza_render_float (sizex, sizey, data, i1, i2, j1, j2, fg, bg, extend, filter, affine);
+    }
   giza_restore_colour_table();
 }
 


### PR DESCRIPTION
The June fix for #7 corrected positive-image rendering, but the other half of the original report remained: swapping FG and BG — PGGRAY's idiom for a negative image — produced output **byte-identical** to the positive (verified with `cmp`).

**Cause:** `giza_render_gray_shade` passes `(bg, fg)` through as `(valMin, valMax)`, with a comment claiming an inverted image is thereby handled without inverting the table. But the value normalisation in `giza-itf.c` is deliberately symmetric under min/max exchange — both argument orders reduce to `(val − min)/(max − min)` — so the fractional position, and hence the image, cannot depend on the order. The promised inversion is mathematically unreachable.

**Fix:** when `fg < bg`, render with the levels in ascending order and a white→black ramp, inverting through the colour table instead. Positive images are byte-for-byte unchanged; the change is confined to `giza_render_gray_shade`/`_float`.

**Verification against PGPLOT 5.3.1:** a Gaussian blob rendered with `FG=0, BG=1`:

| | edge | centre |
|---|---|---|
| PGPLOT 5.3.1 | 255,255,255 | 9,9,9 |
| giza before | 0 (identical to positive) | 245 |
| giza after | **255** | **9** |

perl-PGPLOT suite passes throughout.