### PR TITLE
Fix character sizing scaling

### DIFF
--- a/src/giza-character-size.c
+++ b/src/giza-character-size.c
@@ -184,16 +184,16 @@ giza_get_character_size (int units, double *heightx, double *heighty)
    switch (units)
    {
    case GIZA_UNITS_PIXELS:
-      *heightx = *heightx * Dev[id].deviceUnitsPerPixel;
-      *heighty = *heighty * Dev[id].deviceUnitsPerPixel;
+      *heightx = *heightx / Dev[id].deviceUnitsPerPixel;
+      *heighty = *heighty / Dev[id].deviceUnitsPerPixel;
       break;
    case GIZA_UNITS_MM:
-      *heightx = *heightx * Dev[id].deviceUnitsPermm;
-      *heighty = *heighty * Dev[id].deviceUnitsPermm;
+      *heightx = *heightx / Dev[id].deviceUnitsPermm;
+      *heighty = *heighty / Dev[id].deviceUnitsPermm;
       break;
    case GIZA_UNITS_INCHES:
-      *heightx = *heightx * Dev[id].deviceUnitsPermm/25.4;
-      *heighty = *heighty * Dev[id].deviceUnitsPermm/25.4;
+      *heightx = *heightx / Dev[id].deviceUnitsPermm / 25.4;
+      *heighty = *heighty / Dev[id].deviceUnitsPermm / 25.4;
       break;
    default:
      break;

--- a/src/giza-qtext.c
+++ b/src/giza-qtext.c
@@ -178,18 +178,18 @@ giza_qtextlen (int units, const char *text, double *xlen, double *ylen)
       *ylen = *ylen / Dev[id].height;
       break;
     case GIZA_UNITS_PIXELS:
-      *xlen = *xlen * Dev[id].deviceUnitsPerPixel;
-      *ylen = *ylen * Dev[id].deviceUnitsPerPixel;
+      *xlen = *xlen / Dev[id].deviceUnitsPerPixel;
+      *ylen = *ylen / Dev[id].deviceUnitsPerPixel;
       break;
     case GIZA_UNITS_DEVICE:
       break;
     case GIZA_UNITS_MM:
-      *xlen = *xlen * Dev[id].deviceUnitsPermm;
-      *ylen = *ylen * Dev[id].deviceUnitsPermm;
+      *xlen = *xlen / Dev[id].deviceUnitsPermm;
+      *ylen = *ylen / Dev[id].deviceUnitsPermm;
       break;
     case GIZA_UNITS_INCHES:
-      *xlen = *xlen * Dev[id].deviceUnitsPermm/25.4;
-      *ylen = *ylen * Dev[id].deviceUnitsPermm/25.4;
+      *xlen = *xlen / Dev[id].deviceUnitsPermm / 25.4;
+      *ylen = *ylen / Dev[id].deviceUnitsPermm / 25.4;
       break;
     case GIZA_UNITS_WORLD:
       _giza_set_trans (GIZA_TRANS_NORM);


### PR DESCRIPTION
## Background

It seems like there are a couple places where the device unit to target unit conversion was mistakenly multiplied instead of divided.

The changes make it match the math in `src/giza-viewport.c`, at least. 

## Context

I was attempting to use this in Bmad (replacing pgplot of course) and found that the font sizes were incredibly tiny. This fix seemed to adjust it to be at least approximately correct.

### Pgplot reference:

<img width="400" alt="image" src="https://github.com/user-attachments/assets/ee63f5d2-c16b-4eae-9666-f265ce5e5f42" />

### Giza before this PR: 

<img width="400" alt="image" src="https://github.com/user-attachments/assets/f3994d80-cc2a-4d4a-a161-ae86d9940867" />

### Giza after this PR: 

<img width="400" alt="image" src="https://github.com/user-attachments/assets/5ac55610-1772-481a-bff8-61134eac3ea1" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected character-size and text-length conversions for pixel, millimetre, and inch measurements.
  * Ensured displayed and calculated dimensions now use accurate device scaling across supported units.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->