### PR TITLE
Allow for testing of cairo without X

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -92,6 +92,22 @@ PKG_CHECK_MODULES([X11], [x11], [], [AC_SUBST(X11_LIBS,$x11_libs)])
 PKG_CHECK_MODULES([FT], [freetype2], [], [AC_SUBST(FT_LIBS,$ft_libs_osx)  AC_SUBST(FT_CFLAGS,$ft_cflags_osx)])
 PKG_CHECK_MODULES([FC], [fontconfig], [], [AC_SUBST(FC_LIBS,$fc_libs_osx) AC_SUBST(FC_CFLAGS,$fc_cflags_osx)])
 
+# --- X window driver ---
+# Check for the Cairo X11 backend
+AC_MSG_CHECKING([for cairo xlib backend])
+giza_save_CPPFLAGS=$CPPFLAGS
+CPPFLAGS="$CPPFLAGS $CAIRO_CFLAGS $X11_CFLAGS"
+AC_COMPILE_IFELSE(
+    [AC_LANG_PROGRAM([[#include <cairo/cairo-xlib.h>
+#include <X11/Xlib.h>]],
+                     [[cairo_surface_t *s = cairo_xlib_surface_create (NULL, 0, NULL, 1, 1);
+(void) s;]])],
+    [HAVE_CAIRO_XLIB=yes],
+    [HAVE_CAIRO_XLIB=no])
+CPPFLAGS=$giza_save_CPPFLAGS
+AC_MSG_RESULT([$HAVE_CAIRO_XLIB])
+AM_CONDITIONAL([HAVE_CAIRO_XLIB],[test "x$HAVE_CAIRO_XLIB" = "xyes"])
+
 # --- macOS native Quartz window driver ---
 OSXCOCOA_CFLAGS=""
 OSXCOCOA_LIBS=""

--- a/test/C/Makefile.am
+++ b/test/C/Makefile.am
@@ -1,6 +1,6 @@
 AM_CFLAGS = $(WERROR_CFLAGS) $(WARN_CFLAGS)
 AM_CPPFLAGS = -I../../src -I../../include $(CAIRO_CFLAGS) $(X11_CFLAGS)
-AM_LDFLAGS = -no-install -lm -lX11
+AM_LDFLAGS = -no-install -lm
 LDADD = ../../src/libgiza.la
 
 CPGPLOT_LDADD = ../../src/libcpgplot.la ../../src/libgiza.la
@@ -16,14 +16,18 @@ auto_ctests = test-format-number test-giza-round test-glyph-fallback test-pdf te
 	test-cpgpnts test-cpgconb test-cpgconf test-cpgconl test-cpgconx test-cpghi2d test-cpgscrl test-pggray
 
 # Tests that need an X display (use /xw or "?" which defaults to /xw)
-interactive_ctests = test-arrow test-box test-cairo-xw test-change-page \
+interactive_ctests = test-arrow test-box test-change-page \
 	test-circle test-colour-index \
 	test-environment \
 	test-error-bars test-giza-xw test-line-cap \
 	test-line-style test-openclose test-points \
 	test-qtext test-rectangle test-set-line-width \
-	test-vector test-window test-XOpenDisplay test-contour test-render \
+	test-vector test-window test-contour test-render \
 	test-band
+
+if HAVE_CAIRO_XLIB
+interactive_ctests += test-cairo-xw test-XOpenDisplay
+endif
 
 TESTS = $(auto_ctests)
 check_PROGRAMS = $(auto_ctests) $(interactive_ctests)


### PR DESCRIPTION
## Changes

* Add a `HAVE_CAIRO_XLIB` flag to check if X11 support for cairo is available
* Avoid running tests that require cairo's X11 support

## Background

Not all builds of Cairo have X11 compiled in.
Importantly for me, at least, is the conda-forge release of cairo. (ref: https://github.com/conda-forge/cairo-feedstock/issues/22)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility on systems without Cairo Xlib support by detecting availability during configuration.
  * Prevented unrelated test failures caused by requiring X11 libraries when the Cairo Xlib backend is unavailable.

* **Tests**
  * Cairo Xlib and X11 display tests now run only when the required backend is detected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->